### PR TITLE
Rename from magodo/aztfy to Azure/aztfy

### DIFF
--- a/.tools/generate-provider-schema/generate-provider-schema/main.go
+++ b/.tools/generate-provider-schema/generate-provider-schema/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	tfyschema "github.com/Azure/aztfy/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	tfyschema "github.com/magodo/aztfy/schema"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Azure Terrafy imports the resources inside a resource group, which are supported
 
 ### From Release
 
-Precompiled binaries for Windows, OS X, Linux are available at [Releases](https://github.com/magodo/aztfy/releases).
+Precompiled binaries for Windows, OS X, Linux are available at [Releases](https://github.com/Azure/aztfy/releases).
 
 Note: The release is in the format of `.tar.gz`, Windows users might want to have [7zip](https://www.7-zip.org/download.html) installed to extract the files.
 
 ### From Go toolchain
 
 ```bash
-go install github.com/magodo/aztfy@latest
+go install github.com/Azure/aztfy@latest
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/magodo/aztfy
+module github.com/Azure/aztfy
 
 go 1.17
 

--- a/internal/armtemplate/armtemplate_test.go
+++ b/internal/armtemplate/armtemplate_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/magodo/aztfy/internal/armtemplate"
+	"github.com/Azure/aztfy/internal/armtemplate"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/meta/hcl_schema.go
+++ b/internal/meta/hcl_schema.go
@@ -2,12 +2,13 @@ package meta
 
 import (
 	"fmt"
-	"github.com/hashicorp/hcl/v2"
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/Azure/aztfy/schema"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/magodo/aztfy/schema"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,6 +1,6 @@
 package meta
 
-import "github.com/magodo/aztfy/internal/config"
+import "github.com/Azure/aztfy/internal/config"
 
 type Meta interface {
 	Init() error

--- a/internal/meta/meta_impl.go
+++ b/internal/meta/meta_impl.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/magodo/aztfy/internal/armtemplate"
-	"github.com/magodo/aztfy/schema"
+	"github.com/Azure/aztfy/internal/armtemplate"
+	"github.com/Azure/aztfy/schema"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/hashicorp/go-version"

--- a/internal/ui/aztfyclient/client.go
+++ b/internal/ui/aztfyclient/client.go
@@ -3,8 +3,8 @@ package aztfyclient
 import (
 	"time"
 
-	"github.com/magodo/aztfy/internal/config"
-	"github.com/magodo/aztfy/internal/meta"
+	"github.com/Azure/aztfy/internal/config"
+	"github.com/Azure/aztfy/internal/meta"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/internal/ui/importlist/importlist.go
+++ b/internal/ui/importlist/importlist.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/magodo/aztfy/internal/meta"
-	"github.com/magodo/aztfy/internal/ui/aztfyclient"
-	"github.com/magodo/aztfy/internal/ui/common"
-	"github.com/magodo/aztfy/mapping"
-	"github.com/magodo/aztfy/schema"
+	"github.com/Azure/aztfy/internal/meta"
+	"github.com/Azure/aztfy/internal/ui/aztfyclient"
+	"github.com/Azure/aztfy/internal/ui/common"
+	"github.com/Azure/aztfy/mapping"
+	"github.com/Azure/aztfy/schema"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"

--- a/internal/ui/importlist/importlist_delegate.go
+++ b/internal/ui/importlist/importlist_delegate.go
@@ -3,9 +3,10 @@ package importlist
 import (
 	"errors"
 	"fmt"
-	"github.com/magodo/aztfy/internal/ui/common"
-	"github.com/magodo/aztfy/schema"
 	"strings"
+
+	"github.com/Azure/aztfy/internal/ui/common"
+	"github.com/Azure/aztfy/schema"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/ui/importlist/item.go
+++ b/internal/ui/importlist/item.go
@@ -1,8 +1,8 @@
 package importlist
 
 import (
-	"github.com/magodo/aztfy/internal/meta"
-	"github.com/magodo/aztfy/internal/ui/common"
+	"github.com/Azure/aztfy/internal/meta"
+	"github.com/Azure/aztfy/internal/ui/common"
 	"github.com/magodo/textinput"
 )
 

--- a/internal/ui/progress/progress.go
+++ b/internal/ui/progress/progress.go
@@ -3,11 +3,11 @@ package progress
 import (
 	"fmt"
 
+	"github.com/Azure/aztfy/internal/meta"
+	"github.com/Azure/aztfy/internal/ui/aztfyclient"
+	"github.com/Azure/aztfy/internal/ui/common"
 	prog "github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/magodo/aztfy/internal/meta"
-	"github.com/magodo/aztfy/internal/ui/aztfyclient"
-	"github.com/magodo/aztfy/internal/ui/common"
 )
 
 type result struct {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -6,16 +6,16 @@ import (
 	"log"
 	"os"
 
-	"github.com/magodo/aztfy/internal/config"
-	"github.com/magodo/aztfy/internal/meta"
-	"github.com/magodo/aztfy/internal/ui/aztfyclient"
-	"github.com/magodo/aztfy/internal/ui/common"
+	"github.com/Azure/aztfy/internal/config"
+	"github.com/Azure/aztfy/internal/meta"
+	"github.com/Azure/aztfy/internal/ui/aztfyclient"
+	"github.com/Azure/aztfy/internal/ui/common"
 	"github.com/mitchellh/go-wordwrap"
 
 	"github.com/muesli/reflow/indent"
 
-	"github.com/magodo/aztfy/internal/ui/importlist"
-	"github.com/magodo/aztfy/internal/ui/progress"
+	"github.com/Azure/aztfy/internal/ui/importlist"
+	"github.com/Azure/aztfy/internal/ui/progress"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	"flag"
 
-	"github.com/magodo/aztfy/internal/config"
-	"github.com/magodo/aztfy/internal/ui"
+	"github.com/Azure/aztfy/internal/config"
+	"github.com/Azure/aztfy/internal/ui"
 )
 
 var (


### PR DESCRIPTION
## Why

aztfy has moved under Azure org.

## What

Change path(go import / README) from magodo/aztfy to Azure/aztfy. 