### PR TITLE
new key binding `s`: save resoure mapping

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -2,6 +2,8 @@ package meta
 
 import "github.com/Azure/aztfy/internal/config"
 
+const ResourceMappingFileName = ".aztfyResourceMapping.json"
+
 type Meta interface {
 	Init() error
 	ResourceGroupName() string

--- a/internal/meta/meta_impl.go
+++ b/internal/meta/meta_impl.go
@@ -253,7 +253,7 @@ func (meta MetaImpl) ExportResourceMapping(l ImportList) error {
 		}
 		m[item.ResourceID] = item.TFResourceType
 	}
-	output := filepath.Join(meta.outdir, ".aztfyResourceMapping.json")
+	output := filepath.Join(meta.outdir, ResourceMappingFileName)
 	b, err := json.MarshalIndent(m, "", "\t")
 	if err != nil {
 		return fmt.Errorf("JSON marshalling the resource mapping: %v", err)

--- a/internal/ui/importlist/importlist.go
+++ b/internal/ui/importlist/importlist.go
@@ -142,6 +142,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return m, m.list.NewStatusMessage(common.InfoStyle.Render("No resource type recommendation is avaialble..."))
 			}
 			return m, m.list.NewStatusMessage(common.InfoStyle.Render(fmt.Sprintf("Possible resource type(s): %s", strings.Join(recs, ","))))
+		case key.Matches(msg, m.listkeys.save):
+			m.list.NewStatusMessage(common.InfoStyle.Render("Saving the resouce mapping..."))
+			err := m.c.ExportResourceMapping(m.importList(false))
+			if err == nil {
+				m.list.NewStatusMessage(common.InfoStyle.Render(fmt.Sprintf("Resource mapping saved to %s.", meta.ResourceMappingFileName)))
+			} else {
+				m.list.NewStatusMessage(common.ErrorMsgStyle.Render(err.Error()))
+			}
 		}
 	case tea.WindowSizeMsg:
 		// The height here minus the height occupied by the title

--- a/internal/ui/importlist/listkey.go
+++ b/internal/ui/importlist/listkey.go
@@ -6,13 +6,14 @@ type listKeyMap struct {
 	apply          key.Binding
 	error          key.Binding
 	recommendation key.Binding
+	save           key.Binding
 }
 
 func newListKeyMap() listKeyMap {
 	return listKeyMap{
 		apply: key.NewBinding(
 			key.WithKeys("w"),
-			key.WithHelp("w", "save"),
+			key.WithHelp("w", "import"),
 		),
 		error: key.NewBinding(
 			key.WithKeys("e"),
@@ -22,6 +23,10 @@ func newListKeyMap() listKeyMap {
 			key.WithKeys("r"),
 			key.WithHelp("r", "show recommendation"),
 		),
+		save: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "save"),
+		),
 	}
 }
 
@@ -30,5 +35,6 @@ func (m listKeyMap) ToBindings() []key.Binding {
 		m.apply,
 		m.error,
 		m.recommendation,
+		m.save,
 	}
 }


### PR DESCRIPTION
The interactive mode now has a keybinding `s`, which is used to allow users to save the typed resource mapping into the `.aztfyResourceMapping` file.