### PR TITLE
Recrod `aztfy` in `user-agent` HTTP header

### DIFF
--- a/internal/meta/meta_impl.go
+++ b/internal/meta/meta_impl.go
@@ -123,6 +123,9 @@ func newMetaImpl(cfg config.Config) (Meta, error) {
 		}
 	}
 
+	// AzureRM provider will honor env.var "AZURE_HTTP_USER_AGENT" when constructing for HTTP "User-Agent" header.
+	os.Setenv("AZURE_HTTP_USER_AGENT", "aztfy")
+
 	meta := &MetaImpl{
 		subscriptionId:  auth.Config.SubscriptionID,
 		resourceGroup:   cfg.ResourceGroupName,


### PR DESCRIPTION
Always export the env var `AZURE_HTTP_USER_AGENT` when running `aztfy` so that the API from the AzureRM provider will append the `aztfy` in the `User-Agent` HTTP header.