### PR TITLE
Generate schema and resource id mapping for v3.0.2

### DIFF
--- a/schema/provider_gen.go
+++ b/schema/provider_gen.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-var ProviderVersion = "3.0.1"
+var ProviderVersion = "3.0.2"
 
 var ProviderSchemaInfo ProviderSchema
 

--- a/schema/provider_gen.go
+++ b/schema/provider_gen.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-var ProviderVersion = "3.0.0"
+var ProviderVersion = "3.0.1"
 
 var ProviderSchemaInfo ProviderSchema
 


### PR DESCRIPTION
## Why

terraform-provider-azurerm of current version is v3.0.1

ref https://github.com/hashicorp/terraform-provider-azurerm/compare/v3.0.0...v3.0.1
ref https://github.com/hashicorp/terraform-provider-azurerm/compare/v3.0.1...v3.0.2

## What

`PROVIDER_DIR=/Users/sakabekodai/src/github.com/hashicorp/terraform-provider-azurerm PROVIDER_VERSION=3.0.2 make gen`