### PR TITLE
Set version in build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
           output=aztfy.exe
         fi
 
-        GOOS="${OS}" GOARCH="${ARCH}" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o $output
+        GOOS="${OS}" GOARCH="${ARCH}" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X 'main.version=${VERSION}'" -o $output
         pkg="aztfy_${VERSION}_${OS}_${ARCH}.zip"
         zip $pkg $output
         rm $output

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var version string = "v0.0.8"
+var version string = "dev"


### PR DESCRIPTION
Set version in build pipeline. Though we shall make the version more explicit for users using `go install` or building from source, for the sake of identifying problems in issues, etc. But as this tool is one shot purpose, it is fine for now.