### PR TITLE
Include in license file a copyright notice from the Hashicorp OSS project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Portions Copyright © HashiCorp
+Portions Copyright © Microsoft Corporation
+
 Mozilla Public License, version 2.0
 
 1. Definitions


### PR DESCRIPTION
This s is a legal attribution requirement under the MPLv2 license terms.