### PR TITLE
Fix pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ for os_arch in "${OS_ARCH[@]}" ; do
   ARCH=${os_arch#*:}
   echo "GOOS: ${OS}, GOARCH: ${ARCH}"
 
-  output=aztfy_$OS_$ARCH
+  output=aztfy_${OS}_${ARCH}
   if [[ $OS = windows ]]; then
     output=$output.exe
   fi


### PR DESCRIPTION
`$OS_$ARCH` is resolved as `${OS_}${ARCH}` when epxanding the paramter, as in Bash the `_` is also a valid character as name. This PR explicitly set quote both variables with braces.