### PR TITLE
Update TF version constraint to include v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Precompiled binaries are available at [Releases](https://github.com/Azure/aztfy/
 go install github.com/Azure/aztfy@latest
 ```
 
+## Precondition
+
+There is no special precondtion needed for running `aztfy`, except that you have access to Azure.
+
+Although `aztfy` depends on `terraform`, it is not required to have `terraform` pre-installed and configured in the [`PATH`](https://en.wikipedia.org/wiki/PATH_(variable)) before running `aztfy`. `aztfy` will ensure a `terraform` in the following order: 
+
+- If there is already a `terraform` discovered in the `PATH` whose version `>= v0.12`, then use it
+- Otherwise, if there is already a `terraform` installed at the `aztfy` cache directory, then use it
+- Otherwise, install the latest `terraform` from Hashicorp's release to the `aztfy` cache directory
+
+(The `aztfy` cache directory is at: "[\<UserCacheDir\>](https://pkg.go.dev/os#UserCacheDir)/aztfy")
+
 ## Usage
 
 Follow the [authentication guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure) from the Terraform AzureRM provider to authenticate to Azure.

--- a/internal/meta/tfinstall_find.go
+++ b/internal/meta/tfinstall_find.go
@@ -18,7 +18,7 @@ func FindTerraform(ctx context.Context, tfDir string) (string, error) {
 		&fs.AnyVersion{
 			Product:     &product.Terraform,
 			ExtraPaths:  []string{tfDir},
-			Constraints: version.MustConstraints(version.NewConstraint(">0.12")),
+			Constraints: version.MustConstraints(version.NewConstraint(">=0.12")),
 		},
 		&checkpoint.LatestVersion{
 			Product:    product.Terraform,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ for os_arch in "${OS_ARCH[@]}" ; do
   ARCH=${os_arch#*:}
   echo "GOOS: ${OS}, GOARCH: ${ARCH}"
 
-  output=aztfy_$OS_$ARCH
+  output=aztfy_${OS}_${ARCH}
   if [[ $OS = windows ]]; then
     output=$output.exe
   fi


### PR DESCRIPTION
Update TF version constraint to include v0.12, also mention the precondition in the README.