### PR TITLE
Remove replace in go.mod and use github.com/magodo/hc-install directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/hashicorp/go-azure-helpers v0.16.5
 	github.com/hashicorp/go-version v1.4.0
-	github.com/hashicorp/hc-install v0.3.1
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-exec v0.16.0
+	github.com/magodo/hc-install v0.3.2-0.20220504032610-94e9000c1f9c
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
 	github.com/magodo/tfadd v0.4.0
 	github.com/meowgorithm/babyenv v1.3.1
@@ -81,5 +81,3 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-
-replace github.com/hashicorp/hc-install => github.com/magodo/hc-install v0.3.2-0.20220411071935-84486ab39b72

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/hc-install v0.3.1 h1:VIjllE6KyAI1A244G8kTaHXy+TL5/XYzvrtFi8po/Yk=
+github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsKohGjugbZdZak=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
@@ -208,8 +210,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/magodo/hc-install v0.3.2-0.20220411071935-84486ab39b72 h1:lGybPSWCyGqnuEqzp1/u+5V+/ceAIoYUsvasiJ0wcvE=
-github.com/magodo/hc-install v0.3.2-0.20220411071935-84486ab39b72/go.mod h1:6qzl/Pm6PE2FLMd0N7Gi6r3XjqdNbtihoWtGmaNXtaw=
+github.com/magodo/hc-install v0.3.2-0.20220504032610-94e9000c1f9c h1:TOkELXKtNN2AUsuRStlbIe3Pe6PTbJabrUJc4lsRh5g=
+github.com/magodo/hc-install v0.3.2-0.20220504032610-94e9000c1f9c/go.mod h1:HLRx06SlXH62I5+tDiqf7ObccrTIjvmu8bnclQXyRlc=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0/go.mod h1:MqYhNP+PC386Bjsx5piZe7T4vDm5QIPv8b1RU0prVnU=
 github.com/magodo/tfadd v0.4.0 h1:ONvTfavfo5PrXiaSVnrVT6VYs7t7fis3AJ4LOSUuofw=

--- a/internal/meta/tfinstall_find.go
+++ b/internal/meta/tfinstall_find.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-version"
-	install "github.com/hashicorp/hc-install"
-	"github.com/hashicorp/hc-install/checkpoint"
-	"github.com/hashicorp/hc-install/fs"
-	"github.com/hashicorp/hc-install/product"
-	"github.com/hashicorp/hc-install/src"
+	install "github.com/magodo/hc-install"
+	"github.com/magodo/hc-install/checkpoint"
+	"github.com/magodo/hc-install/fs"
+	"github.com/magodo/hc-install/product"
+	"github.com/magodo/hc-install/src"
 )
 
 // FindTerraform finds the path to the terraform executable.


### PR DESCRIPTION
Remove replace in go.mod and use github.com/magodo/hc-install directly. This is to avoid `go install` error due to `replace` directive used in go.mod, as is stated in https://github.com/golang/go/issues/44840. The fork can be later removed and using the upstream one, once https://github.com/hashicorp/hc-install/pull/52 is merged.

Fixes #80 