### PR TITLE
Post-ARM template export step for fixing some known ARM template issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
+	github.com/tidwall/gjson v1.14.1 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/muesli/reflow v0.3.0
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.14.1
 )
 
 require (
@@ -64,7 +65,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
-	github.com/tidwall/gjson v1.14.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,12 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/gjson v1.14.1 h1:iymTbGkQBhveq21bEvAQ81I0LEBork8BFe1CUZXdyuo=
+github.com/tidwall/gjson v1.14.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/armtemplate/armtemplate_hack.go
+++ b/internal/armtemplate/armtemplate_hack.go
@@ -1,0 +1,70 @@
+package armtemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// PopulateManagedResources populate extra resources that are missing from ARM template due to they are exclusively managed by another resource.
+// E.g. managed disk resource id is not returned via ARM template as it is exclusively managed by VM.
+// Terraform models the resources differently than ARM template and needs to import those managed resources separately.
+func (tpl *Template) PopulateManagedResources() error {
+	oldResources := make([]Resource, len(tpl.Resources))
+	copy(oldResources, tpl.Resources)
+	for _, res := range oldResources {
+		switch res.Type {
+		case "Microsoft.Compute/virtualMachines":
+			resources, err := populateManagedResources(res.Properties, "storageProfile.dataDisks.#.managedDisk.id")
+			if err != nil {
+				return fmt.Errorf(`populating managed resources for "Microsoft.Compute/virtualMachines": %v`, err)
+			}
+			tpl.Resources = append(tpl.Resources, resources...)
+		}
+	}
+	return nil
+}
+
+func populateManagedResources(props interface{}, paths ...string) ([]Resource, error) {
+	b, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling %v: %v", props, err)
+	}
+	var resources []Resource
+	for _, path := range paths {
+		result := gjson.GetBytes(b, path)
+		if !result.Exists() {
+			continue
+		}
+
+		for _, exprResult := range result.Array() {
+			// ARM template export ids in two forms:
+			// - Call expression: [resourceids(type, args)]. This is for resources within current export scope.
+			// - Id literal: This is for resources beyond current export scope .
+			if !strings.HasPrefix(exprResult.String(), "[") {
+				continue
+			}
+			id, err := NewResourceIdFromCallExpr(exprResult.String())
+			if err != nil {
+				return nil, err
+			}
+
+			// Ideally, we should recursively export ARM template for this resource, fill in its properties
+			// and populate any managed resources within it, unless it has already exported.
+			// But here, as we explicitly pick up the managed resource to be populated, which means it is rarely possible that
+			// these resource are exported by the ARM template.
+			// TODO: needs to recursively populate these resources?
+			res := Resource{
+				ResourceId: ResourceId{
+					Type: id.Type,
+					Name: id.Name,
+				},
+				DependsOn: []ResourceId{},
+			}
+			resources = append(resources, res)
+		}
+	}
+	return resources, nil
+}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -8,7 +8,7 @@ type Meta interface {
 	Init() error
 	ResourceGroupName() string
 	Workspace() string
-	ListResource() ImportList
+	ListResource() (ImportList, error)
 	CleanTFState(addr string)
 	Import(item *ImportItem)
 	GenerateCfg(l ImportList) error

--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -25,7 +25,7 @@ func (m MetaDummy) Workspace() string {
 	return "example-workspace"
 }
 
-func (m MetaDummy) ListResource() ImportList {
+func (m MetaDummy) ListResource() (ImportList, error) {
 	time.Sleep(500 * time.Millisecond)
 	return ImportList{
 		ImportItem{
@@ -43,7 +43,7 @@ func (m MetaDummy) ListResource() ImportList {
 		ImportItem{
 			ResourceID: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg",
 		},
-	}
+	}, nil
 }
 
 func (m MetaDummy) CleanTFState(_ string) {

--- a/internal/meta/meta_impl.go
+++ b/internal/meta/meta_impl.go
@@ -173,15 +173,16 @@ func (meta *MetaImpl) Init() error {
 	if err := meta.initProvider(ctx); err != nil {
 		return err
 	}
-
-	// Export ARM template
-	if err := meta.exportArmTemplate(ctx); err != nil {
-		return err
-	}
 	return nil
 }
 
-func (meta MetaImpl) ListResource() ImportList {
+func (meta *MetaImpl) ListResource() (ImportList, error) {
+	ctx := context.TODO()
+
+	if err := meta.exportArmTemplate(ctx); err != nil {
+		return nil, err
+	}
+
 	var ids []string
 	for _, res := range meta.armTemplate.Resources {
 		ids = append(ids, res.ID(meta.subscriptionId, meta.resourceGroup))
@@ -207,7 +208,7 @@ func (meta MetaImpl) ListResource() ImportList {
 		}
 		l = append(l, item)
 	}
-	return l
+	return l, nil
 }
 
 func (meta *MetaImpl) CleanTFState(addr string) {
@@ -332,6 +333,10 @@ func (meta *MetaImpl) exportArmTemplate(ctx context.Context) error {
 	}
 	if err := json.Unmarshal(raw, &meta.armTemplate); err != nil {
 		return fmt.Errorf("unmarshalling the template: %w", err)
+	}
+
+	if err := meta.armTemplate.PopulateManagedResources(); err != nil {
+		return fmt.Errorf("populating managed resources in the ARM template: %v", err)
 	}
 
 	return nil

--- a/internal/ui/aztfyclient/client.go
+++ b/internal/ui/aztfyclient/client.go
@@ -66,7 +66,11 @@ func Init(c meta.Meta) tea.Cmd {
 
 func ListResource(c meta.Meta) tea.Cmd {
 	return func() tea.Msg {
-		return ListResourceDoneMsg{List: c.ListResource()}
+		list, err := c.ListResource()
+		if err != nil {
+			return ErrMsg(err)
+		}
+		return ListResourceDoneMsg{List: list}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -195,7 +195,10 @@ func batchImport(cfg config.Config, continueOnError bool) error {
 	}
 
 	fmt.Println("List resources...")
-	list := c.ListResource()
+	list, err := c.ListResource()
+	if err != nil {
+		return err
+	}
 
 	fmt.Println("Import resources...")
 	for i := range list {


### PR DESCRIPTION
This PR adds an additional step after getting the exported ARM template, to mitigate the issue that ARM template doesn't list some resource that is marked as `managedBy` other resource. Especially, we add a such case for managed disk when attatched to a VM, to fix #77.