### PR TITLE
Introduce Id transform during resource listing & Post HCL lifecycle addon 

### DIFF
--- a/internal/armtemplate/armtemplate.go
+++ b/internal/armtemplate/armtemplate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/Azure/aztfy/internal/client"
 )
 
 type Template struct {
@@ -24,7 +26,52 @@ type ResourceId struct {
 
 var ResourceGroupId = ResourceId{}
 
-func NewResourceIdFromCallExpr(expr string) (*ResourceId, error) {
+func ParseResourceId(id string) (*ResourceId, error) {
+	id = strings.TrimPrefix(id, "/")
+	id = strings.TrimSuffix(id, "/")
+	segs := strings.Split(id, "/")
+	if len(segs)%2 != 0 {
+		return nil, fmt.Errorf("invalid resource id format of %q: amount of segments is not even", id)
+	}
+	// ==4: resource group
+	// >=8: general resources resides in a resource group
+	if len(segs) != 4 && len(segs) < 8 {
+		return nil, fmt.Errorf("invalid resource id format of %q: amount of segments is too small", id)
+	}
+	if segs[0] != "subscriptions" {
+		return nil, fmt.Errorf("invalid resource id format of %q: the 1st segment is not subscriptions", id)
+	}
+	segs = segs[2:]
+	if !strings.EqualFold(segs[0], "resourcegroups") {
+		return nil, fmt.Errorf("invalid resource id format of %q: the 2nd segment is not resourcegroups (case insensitive)", id)
+	}
+	segs = segs[2:]
+
+	if len(segs) == 0 {
+		return &ResourceGroupId, nil
+	}
+
+	if segs[0] != "providers" {
+		return nil, fmt.Errorf("invalid resource id format of %q: the 3rd segment is not providers", id)
+	}
+	providerName := segs[1]
+	segs = segs[2:]
+
+	t := []string{providerName}
+	n := []string{}
+
+	for i := 0; i < len(segs); i += 2 {
+		t = append(t, segs[i])
+		n = append(n, segs[i+1])
+	}
+
+	return &ResourceId{
+		Type: strings.Join(t, "/"),
+		Name: strings.Join(n, "/"),
+	}, nil
+}
+
+func ParseResourceIdFromCallExpr(expr string) (*ResourceId, error) {
 	matches := regexp.MustCompile(`^\[resourceId\(([^,]+), (.+)\)]$`).FindAllStringSubmatch(expr, 1)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("the resourceId call expression %q is not valid (no match)", expr)
@@ -50,23 +97,24 @@ func NewResourceIdFromCallExpr(expr string) (*ResourceId, error) {
 	}, nil
 }
 
-// ID returns the azure resource id
+// ID converts the ARM ResourceId to its ARM resource ID literal, based on the specified subscription id and resource
+// group name.
 func (res ResourceId) ID(sub, rg string) string {
 	typeSegs := strings.Split(res.Type, "/")
 	nameSegs := strings.Split(res.Name, "/")
 
-	out := []string{"/subscriptions", sub, "resourceGroups", rg}
+	segs := []string{"/subscriptions", sub, "resourceGroups", rg}
 	if len(typeSegs) != 1 {
 		if len(typeSegs)-1 != len(nameSegs) {
 			panic(fmt.Sprintf("The resource of type %q and name %q is not a valid identifier", res.Type, res.Name))
 		}
-		out = append(out, "providers", typeSegs[0])
+		segs = append(segs, "providers", typeSegs[0])
 		for i := 0; i < len(nameSegs); i++ {
-			out = append(out, typeSegs[i+1])
-			out = append(out, nameSegs[i])
+			segs = append(segs, typeSegs[i+1])
+			segs = append(segs, nameSegs[i])
 		}
 	}
-	return strings.Join(out, "/")
+	return strings.Join(segs, "/")
 }
 
 type ResourceIds []ResourceId
@@ -79,7 +127,7 @@ func (resids *ResourceIds) UnmarshalJSON(b []byte) error {
 
 	var ids ResourceIds
 	for _, residExpr := range residExprs {
-		id, err := NewResourceIdFromCallExpr(residExpr)
+		id, err := ParseResourceIdFromCallExpr(residExpr)
 		if err != nil {
 			return err
 		}
@@ -101,32 +149,43 @@ type FQResource struct {
 	DependsOn  []string
 }
 
-func (tpl FQTemplate) DependencyInfo() map[string][]string {
+func (tpl FQTemplate) DependencyInfo() (map[string][]string, error) {
 	s := map[string][]string{}
 	for _, res := range tpl.Resources {
 		if len(res.DependsOn) == 0 {
-			s[res.Id] = []string{ResourceGroupId.ID(tpl.subId, tpl.rg)}
+			rgid, _ := ResourceGroupId.ProviderId(tpl.subId, tpl.rg, nil)
+			s[res.Id] = []string{rgid}
 			continue
 		}
 		s[res.Id] = res.DependsOn
 	}
-	return s
+	return s, nil
 }
 
-func (tpl Template) Qualify(subId, rg string) FQTemplate {
+// Qualify converts the raw ARM template to a fully qualified form in turns of the resource ids, where the ids are converted from the
+// ARM resource id expression to the corresponding TF resource id form.
+func (tpl Template) Qualify(subId, rg string, b *client.ClientBuilder) (*FQTemplate, error) {
 	fqtpl := FQTemplate{
 		subId: subId,
 		rg:    rg,
 	}
 	for _, res := range tpl.Resources {
+		id, err := res.ResourceId.ProviderId(subId, rg, b)
+		if err != nil {
+			return nil, err
+		}
 		fqres := FQResource{
-			Id:         res.ResourceId.ID(subId, rg),
+			Id:         id,
 			Properties: res.Properties,
 		}
 		for _, d := range res.DependsOn {
-			fqres.DependsOn = append(fqres.DependsOn, d.ID(subId, rg))
+			id, err := d.ProviderId(subId, rg, b)
+			if err != nil {
+				return nil, err
+			}
+			fqres.DependsOn = append(fqres.DependsOn, id)
 		}
 		fqtpl.Resources = append(fqtpl.Resources, fqres)
 	}
-	return fqtpl
+	return &fqtpl, nil
 }

--- a/internal/armtemplate/armtemplate_test.go
+++ b/internal/armtemplate/armtemplate_test.go
@@ -8,6 +8,153 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseResourceId(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect armtemplate.ResourceId
+		error  bool
+	}{
+		{
+			name:  "empty",
+			input: "",
+			error: true,
+		},
+		{
+			name:  "only subscription",
+			input: "/subscriptions/1234",
+			error: true,
+		},
+		{
+			name:   "only subscription and resource group",
+			input:  "/subscriptions/1234/resourceGroups/rg1",
+			expect: armtemplate.ResourceGroupId,
+		},
+		{
+			name:  "only subscription, resource group and provider",
+			input: "/subscriptions/1234/resourceGroups/rg1/providers/Microsoft.Network",
+			error: true,
+		},
+		{
+			name:  "valid vnet id",
+			input: "/subscriptions/1234/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1",
+			expect: armtemplate.ResourceId{
+				Type: "Microsoft.Network/virtualNetworks",
+				Name: "vnet1",
+			},
+		},
+		{
+			name:  "valid vnet id (small case resourcegroups)",
+			input: "/subscriptions/1234/resourcegroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1",
+			expect: armtemplate.ResourceId{
+				Type: "Microsoft.Network/virtualNetworks",
+				Name: "vnet1",
+			},
+		},
+		{
+			name:  "invalid subnet id",
+			input: "/subscriptions/1234/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets",
+			error: true,
+		},
+		{
+			name:  "valid subnet id",
+			input: "/subscriptions/1234/resourcegroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1",
+			expect: armtemplate.ResourceId{
+				Type: "Microsoft.Network/virtualNetworks/subnets",
+				Name: "vnet1/subnet1",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		output, err := armtemplate.ParseResourceId(c.input)
+		if c.error {
+			require.Error(t, err, c.name)
+			continue
+		}
+		require.NoError(t, err, c.name)
+		require.Equal(t, c.expect, *output, c.name)
+	}
+}
+
+func TestParseResourceIdFromCallExpr(t *testing.T) {
+	cases := []struct {
+		name   string
+		expr   string
+		expect armtemplate.ResourceId
+		error  bool
+	}{
+		{
+			name:  "empty",
+			expr:  "",
+			error: true,
+		},
+		{
+			name:  "no args",
+			expr:  "[resourceId()]",
+			error: true,
+		},
+		{
+			name: "one level",
+			expr: "[resourceId('Microsoft.Storage/storageAccounts', 'a')]",
+			expect: armtemplate.ResourceId{
+				Type: "Microsoft.Storage/storageAccounts",
+				Name: "a",
+			},
+			error: false,
+		},
+		{
+			name: "two levels",
+			expr: "[resourceId('Microsoft.Storage/storageAccounts/services', 'a', 'b')]",
+			expect: armtemplate.ResourceId{
+				Type: "Microsoft.Storage/storageAccounts/services",
+				Name: "a/b",
+			},
+			error: false,
+		},
+	}
+
+	for _, c := range cases {
+		output, err := armtemplate.ParseResourceIdFromCallExpr(c.expr)
+		if c.error {
+			require.Error(t, err, c.name)
+			continue
+		}
+		require.NoError(t, err, c.name)
+		require.Equal(t, c.expect, *output, c.name)
+	}
+}
+
+func TestResourceId_ID(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  armtemplate.ResourceId
+		expect string
+	}{
+		{
+			name: "one level",
+			input: armtemplate.ResourceId{
+				Type: "Microsoft.Storage/storageAccounts",
+				Name: "a",
+			},
+			expect: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/a",
+		},
+		{
+			name: "two levels",
+			input: armtemplate.ResourceId{
+				Type: "Microsoft.Storage/storageAccounts/services",
+				Name: "a/b",
+			},
+			expect: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/a/services/b",
+		},
+	}
+
+	for _, c := range cases {
+		actual := c.input.ID("sub1", "rg1")
+		require.Equal(t, actual, c.expect, c.name)
+	}
+}
+
 func TestUnmarshalTemplate(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -290,54 +437,10 @@ func TestDependencyInfo(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.expect, c.input.Qualify(c.subId, c.rg).DependencyInfo(), c.name)
-	}
-}
-
-func TestNewResourceIdFromCallExpr(t *testing.T) {
-	cases := []struct {
-		name   string
-		expr   string
-		expect armtemplate.ResourceId
-		error  bool
-	}{
-		{
-			name:  "empty",
-			expr:  "",
-			error: true,
-		},
-		{
-			name:  "no args",
-			expr:  "[resourceId()]",
-			error: true,
-		},
-		{
-			name: "one level",
-			expr: "[resourceId('Microsoft.Storage/storageAccounts', 'a')]",
-			expect: armtemplate.ResourceId{
-				Type: "Microsoft.Storage/storageAccounts",
-				Name: "a",
-			},
-			error: false,
-		},
-		{
-			name: "two levels",
-			expr: "[resourceId('Microsoft.Storage/storageAccounts/services', 'a', 'b')]",
-			expect: armtemplate.ResourceId{
-				Type: "Microsoft.Storage/storageAccounts/services",
-				Name: "a/b",
-			},
-			error: false,
-		},
-	}
-
-	for _, c := range cases {
-		output, err := armtemplate.NewResourceIdFromCallExpr(c.expr)
-		if c.error {
-			require.Error(t, err, c.name)
-			continue
-		}
+		tpl, err := c.input.Qualify(c.subId, c.rg, nil)
 		require.NoError(t, err, c.name)
-		require.Equal(t, c.expect, *output, c.name)
+		deps, _ := tpl.DependencyInfo()
+		require.NoError(t, err, c.name)
+		require.Equal(t, c.expect, deps, c.name)
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,4 +1,4 @@
-package meta
+package client
 
 import (
 	"fmt"

--- a/internal/meta/hcl_edit.go
+++ b/internal/meta/hcl_edit.go
@@ -1,0 +1,57 @@
+package meta
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func hclBlockAppendDependency(body *hclwrite.Body, ids []string, cfgset map[string]ConfigInfo) error {
+	dependencies := []string{}
+	for _, id := range ids {
+		cfg, ok := cfgset[id]
+		if !ok {
+			dependencies = append(dependencies, fmt.Sprintf("# Depending on %q, which is not imported by Terraform.", id))
+			continue
+		}
+		dependencies = append(dependencies, cfg.TFAddr.String()+",")
+	}
+	if len(dependencies) > 0 {
+		src := []byte("depends_on = [\n" + strings.Join(dependencies, "\n") + "\n]")
+		expr, diags := hclwrite.ParseConfig(src, "f", hcl.InitialPos)
+		if diags.HasErrors() {
+			return fmt.Errorf(`building "depends_on" attribute: %s`, diags.Error())
+		}
+
+		body.SetAttributeRaw("depends_on", expr.Body().GetAttribute("depends_on").Expr().BuildTokens(nil))
+	}
+
+	return nil
+}
+
+func hclBlockAppendLifecycle(body *hclwrite.Body, ignoreChanges []string) error {
+	srcs := map[string][]byte{}
+	if len(ignoreChanges) > 0 {
+		for i := range ignoreChanges {
+			ignoreChanges[i] = ignoreChanges[i] + ","
+		}
+		srcs["ignore_changes"] = []byte("ignore_changes = [\n" + strings.Join(ignoreChanges, "\n") + "\n]\n")
+	}
+
+	if len(srcs) == 0 {
+		return nil
+	}
+
+	b := hclwrite.NewBlock("lifecycle", nil)
+	for name, src := range srcs {
+		expr, diags := hclwrite.ParseConfig(src, "f", hcl.InitialPos)
+		if diags.HasErrors() {
+			return fmt.Errorf(`building "lifecycle.%s" attribute: %s`, name, diags.Error())
+		}
+		b.Body().SetAttributeRaw(name, expr.Body().GetAttribute(name).Expr().BuildTokens(nil))
+	}
+	body.AppendBlock(b)
+	return nil
+}

--- a/internal/meta/hcl_edit_test.go
+++ b/internal/meta/hcl_edit_test.go
@@ -1,0 +1,39 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHclBlockAppendLifecycle(t *testing.T) {
+	cases := []struct {
+		name          string
+		ignoreChanges []string
+		expect        string
+	}{
+		{
+			name:          "no lifecycle should be generated",
+			ignoreChanges: nil,
+			expect:        "",
+		},
+		{
+			name:          "with ignore_changes",
+			ignoreChanges: []string{"foo", "bar"},
+			expect: `lifecycle {
+  ignore_changes = [
+    foo,
+    bar,
+  ]
+}
+`,
+		},
+	}
+
+	for _, c := range cases {
+		b := hclwrite.NewFile().Body()
+		require.NoError(t, hclBlockAppendLifecycle(b, c.ignoreChanges), c.name)
+		require.Equal(t, string(hclwrite.Format(b.BuildTokens(nil).Bytes())), c.expect, c.name)
+	}
+}

--- a/internal/meta/meta_impl.go
+++ b/internal/meta/meta_impl.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/aztfy/internal/client"
+
+	"github.com/Azure/aztfy/internal/armtemplate"
 	"github.com/Azure/aztfy/internal/resmap"
 	"github.com/Azure/aztfy/internal/tfaddr"
 
-	"github.com/Azure/aztfy/internal/armtemplate"
 	"github.com/Azure/aztfy/internal/config"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
@@ -31,7 +33,7 @@ type MetaImpl struct {
 	rootdir        string
 	outdir         string
 	tf             *tfexec.Terraform
-	clientBuilder  *ClientBuilder
+	clientBuilder  *client.ClientBuilder
 	armTemplate    armtemplate.FQTemplate
 
 	// Key is azure resource id; Value is terraform resource addr.
@@ -106,7 +108,7 @@ func newMetaImpl(cfg config.Config) (Meta, error) {
 	}
 
 	// Construct client builder
-	b, err := NewClientBuilder()
+	b, err := client.NewClientBuilder()
 	if err != nil {
 		return nil, fmt.Errorf("building authorizer: %w", err)
 	}
@@ -178,7 +180,8 @@ func (meta *MetaImpl) ListResource() (ImportList, error) {
 	for _, res := range meta.armTemplate.Resources {
 		ids = append(ids, res.Id)
 	}
-	ids = append(ids, armtemplate.ResourceGroupId.ID(meta.subscriptionId, meta.resourceGroup))
+	rgid, _ := armtemplate.ResourceGroupId.ProviderId(meta.subscriptionId, meta.resourceGroup, nil)
+	ids = append(ids, rgid)
 
 	l := make(ImportList, 0, len(ids))
 	for i, id := range ids {
@@ -233,10 +236,11 @@ func (meta MetaImpl) GenerateCfg(l ImportList) error {
 	if err != nil {
 		return fmt.Errorf("converting from state to configurations: %w", err)
 	}
-	cfginfos, err = meta.resolveDependency(cfginfos)
+	cfginfos, err = meta.terraformMetaHook(cfginfos)
 	if err != nil {
-		return fmt.Errorf("resolving cross resource dependencies: %w", err)
+		return fmt.Errorf("Terraform HCL meta hook: %w", err)
 	}
+
 	return meta.generateConfig(cfginfos)
 }
 
@@ -329,7 +333,12 @@ func (meta *MetaImpl) exportArmTemplate(ctx context.Context) error {
 	if err := tpl.PopulateManagedResources(); err != nil {
 		return fmt.Errorf("populating managed resources in the ARM template: %v", err)
 	}
-	meta.armTemplate = tpl.Qualify(meta.subscriptionId, meta.resourceGroup)
+
+	fqTpl, err := tpl.Qualify(meta.subscriptionId, meta.resourceGroup, meta.clientBuilder)
+	if err != nil {
+		return err
+	}
+	meta.armTemplate = *fqTpl
 
 	return nil
 }
@@ -356,8 +365,24 @@ func (meta MetaImpl) stateToConfig(ctx context.Context, list ImportList) (Config
 	return out, nil
 }
 
+func (meta MetaImpl) terraformMetaHook(configs ConfigInfos) (ConfigInfos, error) {
+	var err error
+	configs, err = meta.resolveDependency(configs)
+	if err != nil {
+		return nil, fmt.Errorf("resolving cross resource dependencies: %w", err)
+	}
+	configs, err = meta.lifecycleAddon(configs)
+	if err != nil {
+		return nil, fmt.Errorf("adding terraform lifecycle: %w", err)
+	}
+	return configs, nil
+}
+
 func (meta MetaImpl) resolveDependency(configs ConfigInfos) (ConfigInfos, error) {
-	depInfo := meta.armTemplate.DependencyInfo()
+	depInfo, err := meta.armTemplate.DependencyInfo()
+	if err != nil {
+		return nil, err
+	}
 
 	configSet := map[string]ConfigInfo{}
 	for _, cfg := range configs {
@@ -366,8 +391,9 @@ func (meta MetaImpl) resolveDependency(configs ConfigInfos) (ConfigInfos, error)
 
 	// Iterate each config to add dependency by querying the dependency info from arm template.
 	var out ConfigInfos
+	rgid, _ := armtemplate.ResourceGroupId.ProviderId(meta.subscriptionId, meta.resourceGroup, nil)
 	for id, cfg := range configSet {
-		if id == armtemplate.ResourceGroupId.ID(meta.subscriptionId, meta.resourceGroup) {
+		if id == rgid {
 			out = append(out, cfg)
 			continue
 		}
@@ -376,36 +402,13 @@ func (meta MetaImpl) resolveDependency(configs ConfigInfos) (ConfigInfos, error)
 			return nil, fmt.Errorf("can't find resource %q in the arm template", id)
 		}
 
-		if err := meta.hclBlockAppendDependency(cfg.hcl.Body().Blocks()[0].Body(), depInfo[id], configSet); err != nil {
+		if err := hclBlockAppendDependency(cfg.hcl.Body().Blocks()[0].Body(), depInfo[id], configSet); err != nil {
 			return nil, err
 		}
 		out = append(out, cfg)
 	}
 
 	return out, nil
-}
-
-func (meta MetaImpl) hclBlockAppendDependency(body *hclwrite.Body, ids []string, cfgset map[string]ConfigInfo) error {
-	dependencies := []string{}
-	for _, id := range ids {
-		cfg, ok := cfgset[id]
-		if !ok {
-			dependencies = append(dependencies, fmt.Sprintf("# Depending on %q, which is not imported by Terraform.", id))
-			continue
-		}
-		dependencies = append(dependencies, cfg.TFAddr.String()+",")
-	}
-	if len(dependencies) > 0 {
-		src := []byte("depends_on = [\n" + strings.Join(dependencies, "\n") + "\n]")
-		expr, diags := hclwrite.ParseConfig(src, "generate_depends_on", hcl.InitialPos)
-		if diags.HasErrors() {
-			return fmt.Errorf(`building "depends_on" attribute: %s`, diags.Error())
-		}
-
-		body.SetAttributeRaw("depends_on", expr.Body().GetAttribute("depends_on").Expr().BuildTokens(nil))
-	}
-
-	return nil
 }
 
 func (meta MetaImpl) generateConfig(cfgs ConfigInfos) error {

--- a/internal/meta/terraform_hack.go
+++ b/internal/meta/terraform_hack.go
@@ -1,0 +1,47 @@
+package meta
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// lifecycleAddon adds lifecycle meta arguments for some identified resources, which are mandatory to make them usable.
+func (meta MetaImpl) lifecycleAddon(configs ConfigInfos) (ConfigInfos, error) {
+	out := make(ConfigInfos, len(configs))
+	for i, cfg := range configs {
+		switch cfg.TFAddr.Type {
+		case "azurerm_application_insights_web_test":
+			if err := hclBlockAppendLifecycle(cfg.hcl.Body().Blocks()[0].Body(), []string{"tags"}); err != nil {
+				return nil, fmt.Errorf("azurerm_application_insights_web_test: %v", err)
+			}
+		}
+		out[i] = cfg
+	}
+	return out, nil
+}
+
+func (meta MetaImpl) hclBlockAppendDependency(body *hclwrite.Body, ids []string, cfgset map[string]ConfigInfo) error {
+	dependencies := []string{}
+	for _, id := range ids {
+		cfg, ok := cfgset[id]
+		if !ok {
+			dependencies = append(dependencies, fmt.Sprintf("# Depending on %q, which is not imported by Terraform.", id))
+			continue
+		}
+		dependencies = append(dependencies, cfg.TFAddr.String()+",")
+	}
+	if len(dependencies) > 0 {
+		src := []byte("depends_on = [\n" + strings.Join(dependencies, "\n") + "\n]")
+		expr, diags := hclwrite.ParseConfig(src, "generate_depends_on", hcl.InitialPos)
+		if diags.HasErrors() {
+			return fmt.Errorf(`building "depends_on" attribute: %s`, diags.Error())
+		}
+
+		body.SetAttributeRaw("depends_on", expr.Body().GetAttribute("depends_on").Expr().BuildTokens(nil))
+	}
+
+	return nil
+}

--- a/internal/test/case_applicationinsight_webtest.go
+++ b/internal/test/case_applicationinsight_webtest.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/aztfy/internal/resmap"
+)
+
+type CaseApplicationInsightWebTest struct{}
+
+func (CaseApplicationInsightWebTest) Tpl(d Data) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "%[1]s"
+  location = "WestEurope"
+}
+resource "azurerm_application_insights" "test" {
+  name                = "test-%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+resource "azurerm_application_insights_web_test" "test" {
+  name                    = "test-%[2]s"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  kind                    = "ping"
+  geo_locations           = ["us-tx-sn1-azr"]
+  configuration           = <<XML
+<WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="http://microsoft.com" ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, d.RandomRgName(), d.RandomStringOfLength(8))
+}
+
+func (CaseApplicationInsightWebTest) ResourceMapping(d Data) resmap.ResourceMapping {
+	rm := fmt.Sprintf(`{
+"/subscriptions/%[1]s/resourceGroups/%[2]s": "azurerm_resource_group.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/microsoft.insights/components/test-%[3]s": "azurerm_application_insights.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.insights/webTests/test-%[3]s": "azurerm_application_insights_web_test.test"
+}
+`, d.subscriptionId, d.RandomRgName(), d.RandomStringOfLength(8))
+	m := resmap.ResourceMapping{}
+	if err := json.Unmarshal([]byte(rm), &m); err != nil {
+		panic(err)
+	}
+	return m
+}

--- a/internal/test/e2e_test.go
+++ b/internal/test/e2e_test.go
@@ -110,3 +110,10 @@ func TestComputeVMDisk(t *testing.T) {
 	c, d := CaseComputeVMDisk{}, NewData()
 	runCase(t, d, c)
 }
+
+func TestApplicationInsightWebTest(t *testing.T) {
+	t.Parallel()
+	precheck(t)
+	c, d := CaseApplicationInsightWebTest{}, NewData()
+	runCase(t, d, c)
+}


### PR DESCRIPTION
Now the resource listing logic is as below:

- ARM template export into its raw format
- Populate managed resources on top of the ARM template
- Convert the ARM template raw format to fully qualified format with
  subscription id and resource group name. Especially, the resource id
  (both as the resource identifier and as the dependency) is converted
  from its ARM resource id expression form, to its corresponding TF
  resource id literal (this might requires some special transformation
  based on the different formats used between ARM and TF)

From this point on, all the processing is on top of the FQ template,
with only the TF resource id taken into consideration. This makes a
change on the UI, where it previously showed the resource id in ARM
format, whilst now it shows the TF resource ID. This also means the
saved and imported resource mapping file is now using the TF resource
ID format.

After resources are imported and config is generated. Now we not only
adds on the dependency on top of the generated HCL, we also add on for
some necessary lifecycle meta arguments, `ignore_changes` only for now.
This is necessary for resources that by design the service will create
some "known after apply" properties, which normally users will want to
ignore, so that the follow up plan will not introduce diff. An example
is the `tags` for the application insights webtest resource (see the new
e2e test added for details).

Some follow-ups:

- The ID transformation hook can be extended to transform the ID from
  its mgmt plane ID to its data plane alternatives (e.g. for key vault
  nested items)
- The ID transformation hook should introduce a cache, to avoid
  same expensive conversions from running multiple times


## Test

```shell
❯ AZTFY_E2E=1 go test -v ./internal/...
go: downloading github.com/magodo/tfadd v0.6.0
go: downloading github.com/tidwall/gjson v1.14.1
?       github.com/Azure/aztfy/internal [no test files]
=== RUN   TestParseResourceId
--- PASS: TestParseResourceId (0.00s)
=== RUN   TestParseResourceIdFromCallExpr
--- PASS: TestParseResourceIdFromCallExpr (0.00s)
=== RUN   TestResourceId_ID
--- PASS: TestResourceId_ID (0.00s)
=== RUN   TestUnmarshalTemplate
--- PASS: TestUnmarshalTemplate (0.00s)
=== RUN   TestDependencyInfo
--- PASS: TestDependencyInfo (0.00s)
PASS
ok      github.com/Azure/aztfy/internal/armtemplate     0.002s
?       github.com/Azure/aztfy/internal/client  [no test files]
?       github.com/Azure/aztfy/internal/config  [no test files]
=== RUN   TestHclBlockAppendLifecycle
--- PASS: TestHclBlockAppendLifecycle (0.00s)
PASS
ok      github.com/Azure/aztfy/internal/meta    0.130s
?       github.com/Azure/aztfy/internal/resmap  [no test files]
=== RUN   TestComputeVMDisk
=== PAUSE TestComputeVMDisk
=== RUN   TestApplicationInsightWebTest
=== PAUSE TestApplicationInsightWebTest
=== CONT  TestComputeVMDisk
=== CONT  TestApplicationInsightWebTest
Initializing...
Initializing...
List resources...
Import resources...
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj as azurerm_application_insights.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/Microsoft.insights/webTests/test-wmoblvvj as azurerm_application_insights_web_test.test
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/degradationindependencyduration, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/degradationinserverresponsetime, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/digestMailConfiguration, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_billingdatavolumedailyspikeextension, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_canaryextension, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_exceptionchangeextension, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_memoryleakextension, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_securityextensionspackage, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/extension_traceseveritydetector, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/longdependencyduration, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/migrationToAlertRulesCompleted, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/slowpageloadtime, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj/providers/microsoft.insights/components/test-wmoblvvj/ProactiveDetectionConfigs/slowserverresponsetime, skip it
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-wmoblvvj as azurerm_resource_group.test
Generating Terraform configurations...
List resources...
Import resources...
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt/providers/Microsoft.Network/virtualNetworks/aztfy-test-viwmutmt as azurerm_virtual_network.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt/providers/Microsoft.Compute/virtualMachines/aztfy-test-viwmutmt as azurerm_linux_virtual_machine.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt/providers/Microsoft.Compute/disks/aztfy-test-viwmutmt as azurerm_managed_disk.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt/providers/Microsoft.Network/networkInterfaces/aztfy-test-viwmutmt as azurerm_network_interface.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt/providers/Microsoft.Network/virtualNetworks/aztfy-test-viwmutmt/subnets/internal as azurerm_subnet.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-viwmutmt as azurerm_resource_group.test
Generating Terraform configurations...
--- PASS: TestApplicationInsightWebTest (342.54s)
--- PASS: TestComputeVMDisk (495.37s)
PASS
ok      github.com/Azure/aztfy/internal/test    495.499s
?       github.com/Azure/aztfy/internal/tfaddr  [no test files]
?       github.com/Azure/aztfy/internal/ui      [no test files]
?       github.com/Azure/aztfy/internal/ui/aztfyclient  [no test files]
?       github.com/Azure/aztfy/internal/ui/common       [no test files]
?       github.com/Azure/aztfy/internal/ui/importlist   [no test files]
?
```

Fix #89