### PR TITLE
Conslidate the user resource mapping file

### DIFF
--- a/internal/meta/importlist.go
+++ b/internal/meta/importlist.go
@@ -30,7 +30,7 @@ type ImportItem struct {
 }
 
 func (item ImportItem) Skip() bool {
-	return item.TFAddr.Skip()
+	return item.TFAddr.Type == ""
 }
 
 type ImportList []ImportItem

--- a/internal/resmap/resmap.go
+++ b/internal/resmap/resmap.go
@@ -12,11 +12,7 @@ type ResourceMapping map[string]tfaddr.TFAddr
 func (res ResourceMapping) MarshalJSON() ([]byte, error) {
 	m := map[string]string{}
 	for id, addr := range res {
-		addr := addr.String()
-		if addr == "" {
-			addr = tfaddr.TFResourceTypeSkip
-		}
-		m[id] = addr
+		m[id] = addr.String()
 	}
 	return json.Marshal(m)
 }
@@ -29,9 +25,7 @@ func (res *ResourceMapping) UnmarshalJSON(b []byte) error {
 	}
 	for id, addr := range m {
 		var tfAddr tfaddr.TFAddr
-		if addr == tfaddr.TFResourceTypeSkip {
-			tfAddr.Type = tfaddr.TFResourceTypeSkip
-		} else {
+		if addr != "" {
 			pTFAddr, err := tfaddr.ParseTFResourceAddr(addr)
 			if err != nil {
 				return fmt.Errorf("parsing TF address %q: %v", addr, err)

--- a/internal/tfaddr/tf_addr.go
+++ b/internal/tfaddr/tf_addr.go
@@ -5,20 +5,13 @@ import (
 	"strings"
 )
 
-// TFResourceTypeSkip is a special resource type which represents to skip this resource from importing.
-const TFResourceTypeSkip string = "Skip"
-
 type TFAddr struct {
 	Type string
 	Name string
 }
 
-func (res TFAddr) Skip() bool {
-	return res.Type == TFResourceTypeSkip
-}
-
 func (res TFAddr) String() string {
-	if res.Skip() {
+	if res.Type == "" {
 		return ""
 	}
 	return res.Type + "." + res.Name

--- a/internal/ui/common/progress.go
+++ b/internal/ui/common/progress.go
@@ -5,6 +5,6 @@ import "math/rand"
 const ProgressShowLastResults = 5
 
 func RandomHappyEmoji() string {
-	emojis := []rune("🍦🧋🍡🤠👾😭🦊🐯🦆🥨🎏🍔🍒🍥🎮📦🦁🐶🐸🍕🥐🧲🚒🥇🏆🌽")
+	emojis := []rune("🍦🍡🤠👾😭🦊🐯🦆🥨🎏🍔🍒🍥🎮📦🦁🐶🐸🍕🥐🧲🚒🥇🏆🌽")
 	return string(emojis[rand.Intn(len(emojis))])
 }

--- a/internal/ui/importlist/importlist_delegate.go
+++ b/internal/ui/importlist/importlist_delegate.go
@@ -149,7 +149,7 @@ func setListKeyMapEnabled(m *list.Model, enabled bool) {
 func parseInput(input string) (*tfaddr.TFAddr, error) {
 	v := strings.TrimSpace(input)
 	if v == "" {
-		return &tfaddr.TFAddr{Type: tfaddr.TFResourceTypeSkip}, nil
+		return &tfaddr.TFAddr{}, nil
 	}
 
 	addr, err := tfaddr.ParseTFResourceAddr(v)

--- a/internal/ui/progress/progress.go
+++ b/internal/ui/progress/progress.go
@@ -100,16 +100,20 @@ func (m Model) View() string {
 	}
 
 	s := fmt.Sprintf(" %s\n\n", msg)
-
 	for _, res := range m.results {
-		switch {
-		case res.item.Skip():
-			s += fmt.Sprintf("%s %s skipped\n", res.emoji, res.item.ResourceID)
-		default:
-			if res.item.ImportError == nil {
-				s += fmt.Sprintf("%s %s import successfully\n", res.emoji, res.item.ResourceID)
-			} else {
-				s += fmt.Sprintf("%s %s import failed\n", res.emoji, res.item.ResourceID)
+		// This indicates the state before the item is inserted as the to results.
+		if res.item.ResourceID == "" {
+			s += "...\n"
+		} else {
+			switch {
+			case res.item.Skip():
+				s += fmt.Sprintf("%s %s skipped\n", res.emoji, res.item.ResourceID)
+			default:
+				if res.item.ImportError == nil {
+					s += fmt.Sprintf("%s %s import successfully\n", res.emoji, res.item.ResourceID)
+				} else {
+					s += fmt.Sprintf("%s %s import failed\n", res.emoji, res.item.ResourceID)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously, the saved resource mapping file only contains the items that have specified TF resource type. The skipped ones are absent. This is not friendly to resource group that has a large scale of resources, and the current auto deduction capability only provides users a limited set of resource types. This results into a lot of resources missing in the generated resource mapping file.

This PR changes this situation that all the resource listed via ARM template will be in the generated resource mapping file. The skipped ones will be left in the json object with empty string value. To simplify things, we regard empty `TFAddr.Type` as to be skipped in the import list. Especially, when importing with resource mapping file, we will not do auto deduction for resources, which means only the import item specified in the resource mapping with a non empty TF resource type will be marked to import (though users are still able to specify the others to import during the interactive session).

Besides, this PR fixes a UI bug for progress view that is introduced in another PR.

- Fix #90
- Fix #85 