### PR TITLE
Test: add a case for function app slot

### DIFF
--- a/internal/test/case_function_app_slot.go
+++ b/internal/test/case_function_app_slot.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/aztfy/internal/resmap"
+)
+
+type CaseFunctionAppSlot struct{}
+
+func (CaseFunctionAppSlot) Tpl(d Data) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "%[1]s"
+  location = "EastUS2"
+}
+resource "azurerm_storage_account" "test" {
+  name                     = "aztfytest%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+resource "azurerm_service_plan" "test" {
+  name                = "aztfy-test-%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  os_type             = "Windows"
+  sku_name            = "Y1"
+
+}
+resource "azurerm_windows_function_app" "test" {
+  name                       = "aztfy-test-%[2]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  service_plan_id            = azurerm_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  site_config {}
+}
+resource "azurerm_windows_function_app_slot" "test" {
+  name                       = "aztfy-test-%[2]s"
+  function_app_id            = azurerm_windows_function_app.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  site_config {}
+}
+`, d.RandomRgName(), d.RandomStringOfLength(8))
+}
+
+func (CaseFunctionAppSlot) ResourceMapping(d Data) (resmap.ResourceMapping, error) {
+	rm := fmt.Sprintf(`{
+"/subscriptions/%[1]s/resourceGroups/%[2]s": "azurerm_resource_group.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Storage/storageAccounts/aztfytest%[3]s": "azurerm_storage_account.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/serverfarms/aztfy-test-%[3]s": "azurerm_service_plan.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/sites/aztfy-test-%[3]s": "azurerm_windows_function_app.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/sites/aztfy-test-%[3]s/slots/aztfy-test-%[3]s": "azurerm_windows_function_app_slot.test"
+}
+`, d.subscriptionId, d.RandomRgName(), d.RandomStringOfLength(8))
+	m := resmap.ResourceMapping{}
+	if err := json.Unmarshal([]byte(rm), &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/internal/test/e2e_test.go
+++ b/internal/test/e2e_test.go
@@ -128,3 +128,10 @@ func TestKeyVaultNestedItems(t *testing.T) {
 	c, d := CaseKeyVaultNestedItems{}, NewData()
 	runCase(t, d, c)
 }
+
+func TestFunctionAppSlot(t *testing.T) {
+	t.Parallel()
+	precheck(t)
+	c, d := CaseFunctionAppSlot{}, NewData()
+	runCase(t, d, c)
+}


### PR DESCRIPTION
Fix #123 

Test Result:

```shell
❯ AZTFY_E2E=1 go test -timeout=30m -v -run=TestFunctionAppSlot ./internal/test
=== RUN   TestFunctionAppSlot
=== PAUSE TestFunctionAppSlot
=== CONT  TestFunctionAppSlot
...
--- PASS: TestFunctionAppSlot (606.80s)
PASS
ok      github.com/Azure/aztfy/internal/test    606.940s
```