### PR TITLE
Support storage file share

### DIFF
--- a/internal/armtemplate/armtemplate.go
+++ b/internal/armtemplate/armtemplate.go
@@ -144,9 +144,11 @@ type FQTemplate struct {
 }
 
 type FQResource struct {
+	// The Id is representing the TF resource ID.
 	Id         string
 	Properties interface{}
-	DependsOn  []string
+	// The IDs in the DependsOn are TF resource IDs.
+	DependsOn []string
 }
 
 func (tpl FQTemplate) DependencyInfo() (map[string][]string, error) {

--- a/internal/test/case_storage_file_share.go
+++ b/internal/test/case_storage_file_share.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/aztfy/internal/resmap"
+)
+
+type CaseStorageFileShare struct{}
+
+func (CaseStorageFileShare) Tpl(d Data) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "%[1]s"
+  location = "WestEurope"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "aztfy%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+resource "azurerm_storage_share" "test" {
+  name                 = "aztfy%[2]s"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 5
+}
+`, d.RandomRgName(), d.RandomStringOfLength(8))
+}
+
+func (CaseStorageFileShare) ResourceMapping(d Data) (resmap.ResourceMapping, error) {
+	rm := fmt.Sprintf(`{
+"/subscriptions/%[1]s/resourceGroups/%[2]s": "azurerm_resource_group.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Storage/storageAccounts/aztfy%[3]s": "azurerm_storage_account.test",
+"https://aztfy%[3]s.file.core.windows.net/aztfy%[3]s": "azurerm_storage_share.test"
+}
+`, d.subscriptionId, d.RandomRgName(), d.RandomStringOfLength(8))
+	m := resmap.ResourceMapping{}
+	if err := json.Unmarshal([]byte(rm), &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/internal/test/e2e_test.go
+++ b/internal/test/e2e_test.go
@@ -135,3 +135,10 @@ func TestFunctionAppSlot(t *testing.T) {
 	c, d := CaseFunctionAppSlot{}, NewData()
 	runCase(t, d, c)
 }
+
+func TestStorageFileShare(t *testing.T) {
+	t.Parallel()
+	precheck(t)
+	c, d := CaseStorageFileShare{}, NewData()
+	runCase(t, d, c)
+}


### PR DESCRIPTION
Fix #130.

## Test

```shell
💤  AZTFY_E2E=1 go test -timeout=30m -v -run="TestStorageFileShare" ./internal/test/...
=== RUN   TestStorageFileShare
=== PAUSE TestStorageFileShare
=== CONT  TestStorageFileShare
Initializing...
List resources...
Import resources...
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv/providers/Microsoft.Storage/storageAccounts/aztfydvwhdtiv as azurerm_storage_account.test
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv/providers/Microsoft.Storage/storageAccounts/aztfydvwhdtiv/blobServices/default, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv/providers/Microsoft.Storage/storageAccounts/aztfydvwhdtiv/fileServices/default, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv/providers/Microsoft.Storage/storageAccounts/aztfydvwhdtiv/queueServices/default, skip it
[WARN] No mapping information for resource: /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv/providers/Microsoft.Storage/storageAccounts/aztfydvwhdtiv/tableServices/default, skip it
Importing https://aztfydvwhdtiv.file.core.windows.net/aztfydvwhdtiv as azurerm_storage_share.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-dvwhdtiv as azurerm_resource_group.test
Generating Terraform configurations...
--- PASS: TestStorageFileShare (216.97s)
PASS
ok      github.com/Azure/aztfy/internal/test    217.113s
```