### PR TITLE
Normalize resource id for signalr service

### DIFF
--- a/internal/armtemplate/armtemplate_hack.go
+++ b/internal/armtemplate/armtemplate_hack.go
@@ -127,6 +127,8 @@ func populateManagedResourcesByPath(res Resource, paths ...string) (*Resource, [
 // API interaction with ARM, where a non-nil client builder is required.
 func (res ResourceId) ProviderId(sub, rg string, b *client.ClientBuilder) (string, error) {
 	switch res.Type {
+	case "Microsoft.SignalRService/SignalR":
+		return res.providerIdForSignalR(sub, rg, b)
 	case "microsoft.insights/webtests":
 		return res.providerIdForInsightsWebtests(sub, rg, b)
 	case "Microsoft.Network/frontdoors":
@@ -140,6 +142,12 @@ func (res ResourceId) ProviderId(sub, rg string, b *client.ClientBuilder) (strin
 	default:
 		return res.ID(sub, rg), nil
 	}
+}
+
+func (res ResourceId) providerIdForSignalR(sub, rg string, b *client.ClientBuilder) (string, error) {
+	// See issue: https://github.com/Azure/aztfy/issues/154
+	res.Type = "Microsoft.SignalRService/signalR"
+	return res.ID(sub, rg), nil
 }
 
 func (res ResourceId) providerIdForFrontDoor(sub, rg string, b *client.ClientBuilder) (string, error) {

--- a/internal/test/case_signalr_service.go
+++ b/internal/test/case_signalr_service.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/aztfy/internal/resmap"
+)
+
+type CaseSignalRService struct{}
+
+func (CaseSignalRService) Tpl(d Data) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "%[1]s"
+  location = "WestEurope"
+}
+resource "azurerm_signalr_service" "test" {
+  name                = "test-%[2]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+}
+`, d.RandomRgName(), d.RandomStringOfLength(8))
+}
+
+func (CaseSignalRService) ResourceMapping(d Data) (resmap.ResourceMapping, error) {
+	rm := fmt.Sprintf(`{
+"/subscriptions/%[1]s/resourceGroups/%[2]s": "azurerm_resource_group.test",
+"/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.SignalRService/signalR/test-%[3]s": "azurerm_signalr_service.test"
+}
+`, d.subscriptionId, d.RandomRgName(), d.RandomStringOfLength(8))
+	m := resmap.ResourceMapping{}
+	if err := json.Unmarshal([]byte(rm), &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/internal/test/e2e_test.go
+++ b/internal/test/e2e_test.go
@@ -115,6 +115,13 @@ func TestComputeVMDisk(t *testing.T) {
 	runCase(t, d, c)
 }
 
+func TestSignalRService(t *testing.T) {
+	t.Parallel()
+	precheck(t)
+	c, d := CaseSignalRService{}, NewData()
+	runCase(t, d, c)
+}
+
 func TestApplicationInsightWebTest(t *testing.T) {
 	t.Parallel()
 	precheck(t)


### PR DESCRIPTION
Fix #154 

## Test

```shell
💤  AZTFY_E2E=1 go test -timeout=30m -v -run=TestSignalRService ./internal/test
=== RUN   TestSignalRService
=== PAUSE TestSignalRService
=== CONT  TestSignalRService
Initializing...
List resources...
Import resources...
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-oyllyuvm/providers/Microsoft.SignalRService/signalR/test-oyllyuvm as azurerm_signalr_service.test
Importing /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/aztfy-rg-oyllyuvm as azurerm_resource_group.test
Generating Terraform configurations...
--- PASS: TestSignalRService (237.15s)
PASS
ok      github.com/Azure/aztfy/internal/test    237.286s

```