### PR TITLE
Introduce `--type` in resource mode to allow users to explicitly set the TF resource type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b
-	github.com/magodo/aztft v0.1.1-0.20220729083006-79e4c78420d2
+	github.com/magodo/aztft v0.1.1-0.20220808030539-194fd1d2477a
 	github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
 	github.com/magodo/tfadd v0.10.1-0.20220805074855-072d1d99aa78

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b h1:MizLjMfDMkcTcgb9hoevnEhBKsMKdpyIhviKFHWm5qI=
 github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
-github.com/magodo/aztft v0.1.1-0.20220729083006-79e4c78420d2 h1:40uVEH5/Wc+UJfqEgaR2HvafnONVHhRGnog2FoyVRh0=
-github.com/magodo/aztft v0.1.1-0.20220729083006-79e4c78420d2/go.mod h1:Y2cT4j0C9G10svBeXjkUdjsfeP5GfbOyYIkYU/SoDYM=
+github.com/magodo/aztft v0.1.1-0.20220808030539-194fd1d2477a h1:VgXvGIh9ZeFIuIzTwmUDDfWAyEi0sTXOZdci+6yMuyY=
+github.com/magodo/aztft v0.1.1-0.20220808030539-194fd1d2477a/go.mod h1:Y2cT4j0C9G10svBeXjkUdjsfeP5GfbOyYIkYU/SoDYM=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6 h1:CElHO4hPXC+Eivy8sUC/WrnH3jmQzdF2x0lEXBEYul8=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6/go.mod h1:Cn4fFwFH/Ddw9sjWPeSS72bNaxbM+FRXf7pkGEDReq8=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,9 @@ type ResConfig struct {
 
 	// TF resource name
 	ResourceName string
+
+	// TF resource type. If this is empty, then uses aztft to deduce the correct resource type.
+	ResourceType string
 }
 
 func (ResConfig) isConfig() {}

--- a/internal/meta/meta_res.go
+++ b/internal/meta/meta_res.go
@@ -11,6 +11,7 @@ type ResMeta struct {
 	Meta
 	Id           string
 	ResourceName string
+	ResourceType string
 }
 
 func NewResMeta(cfg config.ResConfig) (*ResMeta, error) {
@@ -22,6 +23,7 @@ func NewResMeta(cfg config.ResConfig) (*ResMeta, error) {
 		Meta:         *baseMeta,
 		Id:           cfg.ResourceId,
 		ResourceName: cfg.ResourceName,
+		ResourceType: cfg.ResourceType,
 	}
 	return meta, nil
 }
@@ -38,4 +40,8 @@ func (meta ResMeta) QueryResourceTypeAndId() (string, string, error) {
 		return "", "", fmt.Errorf("expect exactly one resource id, got=%d", len(lid))
 	}
 	return lrt[0], lid[0], nil
+}
+
+func (meta ResMeta) QueryResourceId(rt string) (string, error) {
+	return aztft.QueryId(meta.Id, rt, true)
 }

--- a/internal/run.go
+++ b/internal/run.go
@@ -28,19 +28,30 @@ func ResourceImport(cfg config.ResConfig) error {
 			return err
 		}
 
-		msg.SetStatus("Querying Terraform resource type and id...")
-		rt, tfid, err := c.QueryResourceTypeAndId()
-		if err != nil {
-			return err
-		}
-
 		item := meta.ImportItem{
-			ResourceID: tfid,
 			TFAddr: tfaddr.TFAddr{
-				Type: rt,
 				Name: c.ResourceName,
 			},
 		}
+
+		if c.ResourceType == "" {
+			msg.SetStatus("Querying Terraform resource type and id...")
+			rt, tfid, err := c.QueryResourceTypeAndId()
+			if err != nil {
+				return err
+			}
+			item.ResourceID = tfid
+			item.TFAddr.Type = rt
+		} else {
+			msg.SetStatus("Querying Terraform resource id...")
+			tfid, err := c.QueryResourceId(c.ResourceType)
+			if err != nil {
+				return err
+			}
+			item.ResourceID = tfid
+			item.TFAddr.Type = c.ResourceType
+		}
+
 		msg.SetDetail(fmt.Sprintf(`Resource Type: %s
 Resource Id  : %s`, item.TFAddr.Type, item.ResourceID))
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func main() {
 		hflagMockClient bool
 
 		// res-only flags
-		flagName string
+		flagName    string
+		flagResType string
 	)
 
 	commonFlagsCheck := func() error {
@@ -270,6 +271,12 @@ func main() {
 						Value:       "res-0",
 						Destination: &flagName,
 					},
+					&cli.StringFlag{
+						Name:        "type",
+						EnvVars:     []string{"AZTFY_TYPE"},
+						Usage:       `The Terraform resource type.`,
+						Destination: &flagResType,
+					},
 				}, commonFlags...),
 				Action: func(c *cli.Context) error {
 					if err := commonFlagsCheck(); err != nil {
@@ -321,6 +328,7 @@ func main() {
 						},
 						ResourceId:   resId,
 						ResourceName: flagName,
+						ResourceType: flagResType,
 					}
 
 					return internal.ResourceImport(cfg)


### PR DESCRIPTION
For some cases (e.g. #197), aztft can't resolve the correct TF resource type as the assumption by aztft is no met. Whilst in that case, TF is still able to import that resource. Therefore, we need a way in single resource mode to allow users to explicitly set the TF resource type, similar as the resource mapping file used in rg batch mode.

Fix #197.