### PR TITLE
Fix data plane only resource id incorrectly prefixed by `\` after mapping from azure id to TF id

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b
-	github.com/magodo/aztft v0.1.1-0.20220913023342-ad367d8a5986
+	github.com/magodo/aztft v0.1.1-0.20220921021151-00974eaacf3b
 	github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
 	github.com/magodo/tfadd v0.10.1-0.20220916023425-bc555e8e7bc9

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b h1:MizLjMfDMkcTcgb9hoevnEhBKsMKdpyIhviKFHWm5qI=
 github.com/magodo/armid v0.0.0-20220707115142-d2d9f6fb551b/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
-github.com/magodo/aztft v0.1.1-0.20220913023342-ad367d8a5986 h1:bUqOxAi1PsI5LGEsSktvzvZ+XIrEGU3PHkjsxUY7fUY=
-github.com/magodo/aztft v0.1.1-0.20220913023342-ad367d8a5986/go.mod h1:WvcLoLom5tLx+aVDRbImtg7V/D3avnUEN9YSI3+92n8=
+github.com/magodo/aztft v0.1.1-0.20220921021151-00974eaacf3b h1:W35hmC9kpskBlTWqT6NvWIuyUHIgE8hegyxM2p8mpUs=
+github.com/magodo/aztft v0.1.1-0.20220921021151-00974eaacf3b/go.mod h1:WvcLoLom5tLx+aVDRbImtg7V/D3avnUEN9YSI3+92n8=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6 h1:CElHO4hPXC+Eivy8sUC/WrnH3jmQzdF2x0lEXBEYul8=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6/go.mod h1:Cn4fFwFH/Ddw9sjWPeSS72bNaxbM+FRXf7pkGEDReq8=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=


### PR DESCRIPTION
Fix data plane only resource id incorrectly prefixed by `\` after mapping from azure id to TF id by introducing the fix made in aztft.

Fix #229.