### PR TITLE
CLI option: `-g`/`--generate-mapping-file` to generate resource mapping file

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ In batch mode, instead of interactively specifying the mapping from Azurem resou
 
 ```json
 {
-    "<AZURE RESOURCE ID1 IN UPPERCASE>": {
+    "<Azure resource id1>": {
         "resource_type" : "<terraform resource type>",
         "resource_name" : "<terraform resource name>",
         "resource_id"   : "<terraform resource id>"
     },
-    "<AZURE RESOURCE ID2 IN UPPERCASE>": {
+    "<Azure resource id2>": {
         "resource_type" : "<terraform resource type>",
         "resource_name" : "<terraform resource name>",
         "resource_id"   : "<terraform resource id>"
@@ -170,17 +170,17 @@ Example:
 
 ```json
 {
-	"/SUBSCRIPTIONS/0000/RESOURCEGROUPS/AZTFY-VMDISK": {
+	"/subscriptions/0000/resourceGroups/aztfy-vmdisk": {
 		"resource_id": "/subscriptions/0000/resourceGroups/aztfy-vmdisk",
 		"resource_type": "azurerm_resource_group",
 		"resource_name": "res-1"
 	},
-	"/SUBSCRIPTIONS/0000/RESOURCEGROUPS/AZTFY-VMDISK/PROVIDERS/MICROSOFT.COMPUTE/DISKS/AZTFY-TEST-TEST": {
+	"/subscriptions/0000/resourceGroups/aztfy-vmdisk/providers/Microsoft.Compute/disks/aztfy-test-test": {
 		"resource_id": "/subscriptions/0000/resourceGroups/aztfy-vmdisk/providers/Microsoft.Compute/disks/aztfy-test-test",
 		"resource_type": "azurerm_managed_disk",
 		"resource_name": "res-2"
 	},
-	"/SUBSCRIPTIONS/0000/RESOURCEGROUPS/AZTFY-VMDISK/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/AZTFY-TEST-TEST": {
+	"/subscriptions/0000/resourceGroups/aztfy-vmdisk/providers/Microsoft.Compute/virtualMachines/aztfy-test-test": {
 		"resource_id": "/subscriptions/0000/resourceGroups/aztfy-vmdisk/providers/Microsoft.Compute/virtualMachines/aztfy-test-test",
 		"resource_type": "azurerm_linux_virtual_machine",
 		"resource_name": "res-3"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,17 +9,18 @@ type Config interface {
 }
 
 type CommonConfig struct {
-	SubscriptionId string
-	OutputDir      string
-	Overwrite      bool
-	Append         bool
-	DevProvider    bool
-	BatchMode      bool
-	BackendType    string
-	BackendConfig  []string
-	FullConfig     bool
-	Parallelism    int
-	PlainUI        bool
+	SubscriptionId      string
+	OutputDir           string
+	Overwrite           bool
+	Append              bool
+	DevProvider         bool
+	BatchMode           bool
+	BackendType         string
+	BackendConfig       []string
+	FullConfig          bool
+	Parallelism         int
+	PlainUI             bool
+	GenerateMappingFile bool
 }
 
 type GroupConfig struct {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -224,7 +224,7 @@ func (meta Meta) ExportResourceMapping(l ImportList) error {
 		if item.Skip() {
 			continue
 		}
-		m[strings.ToUpper(item.AzureResourceID.String())] = resmap.ResourceMapEntity{
+		m[item.AzureResourceID.String()] = resmap.ResourceMapEntity{
 			ResourceId:   item.TFResourceId,
 			ResourceType: item.TFAddr.Type,
 			ResourceName: item.TFAddr.Name,

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/Azure/aztfy/internal/client"
 	"github.com/Azure/aztfy/internal/config"
+	"github.com/Azure/aztfy/internal/resmap"
 	"github.com/Azure/aztfy/internal/utils"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/hashicorp/hcl/v2"
@@ -30,6 +32,7 @@ type meta interface {
 	Import(item *ImportItem)
 	CleanTFState(addr string)
 	GenerateCfg(ImportList) error
+	ExportResourceMapping(ImportList) error
 }
 
 var _ meta = &Meta{}
@@ -213,6 +216,29 @@ func (meta Meta) Import(item *ImportItem) {
 
 func (meta Meta) GenerateCfg(l ImportList) error {
 	return meta.generateCfg(l, meta.lifecycleAddon, meta.addDependency)
+}
+
+func (meta Meta) ExportResourceMapping(l ImportList) error {
+	m := resmap.ResourceMapping{}
+	for _, item := range l {
+		if item.Skip() {
+			continue
+		}
+		m[strings.ToUpper(item.AzureResourceID.String())] = resmap.ResourceMapEntity{
+			ResourceId:   item.TFResourceId,
+			ResourceType: item.TFAddr.Type,
+			ResourceName: item.TFAddr.Name,
+		}
+	}
+	output := filepath.Join(meta.Workspace(), ResourceMappingFileName)
+	b, err := json.MarshalIndent(m, "", "\t")
+	if err != nil {
+		return fmt.Errorf("JSON marshalling the resource mapping: %v", err)
+	}
+	if err := os.WriteFile(output, b, 0644); err != nil {
+		return fmt.Errorf("writing the resource mapping to %s: %v", output, err)
+	}
+	return nil
 }
 
 func (meta Meta) generateCfg(l ImportList, cfgTrans ...TFConfigTransformer) error {

--- a/internal/meta/meta_group.go
+++ b/internal/meta/meta_group.go
@@ -4,14 +4,13 @@ import (
 	"github.com/Azure/aztfy/internal/config"
 )
 
-const ResourceMappingFileName = ".aztfyResourceMapping.json"
-const SkippedResourcesFileName = ".aztfySkippedResources.txt"
+const ResourceMappingFileName = "aztfyResourceMapping.json"
+const SkippedResourcesFileName = "aztfySkippedResources.txt"
 
 type GroupMeta interface {
 	meta
 	ScopeName() string
 	ListResource() (ImportList, error)
-	ExportResourceMapping(l ImportList) error
 	ExportSkippedResources(l ImportList) error
 }
 

--- a/internal/meta/meta_group_impl.go
+++ b/internal/meta/meta_group_impl.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,29 +123,6 @@ func (meta *MetaGroupImpl) ListResource() (ImportList, error) {
 		l = append(l, item)
 	}
 	return l, nil
-}
-
-func (meta MetaGroupImpl) ExportResourceMapping(l ImportList) error {
-	m := resmap.ResourceMapping{}
-	for _, item := range l {
-		if item.Skip() {
-			continue
-		}
-		m[strings.ToUpper(item.AzureResourceID.String())] = resmap.ResourceMapEntity{
-			ResourceId:   item.TFResourceId,
-			ResourceType: item.TFAddr.Type,
-			ResourceName: item.TFAddr.Name,
-		}
-	}
-	output := filepath.Join(meta.Workspace(), ResourceMappingFileName)
-	b, err := json.MarshalIndent(m, "", "\t")
-	if err != nil {
-		return fmt.Errorf("JSON marshalling the resource mapping: %v", err)
-	}
-	if err := os.WriteFile(output, b, 0644); err != nil {
-		return fmt.Errorf("writing the resource mapping to %s: %v", output, err)
-	}
-	return nil
 }
 
 func (meta MetaGroupImpl) ExportSkippedResources(l ImportList) error {

--- a/internal/meta/meta_group_impl.go
+++ b/internal/meta/meta_group_impl.go
@@ -105,8 +105,13 @@ func (meta *MetaGroupImpl) ListResource() (ImportList, error) {
 			item.Recommendations = []string{res.TFType}
 		}
 
-		if len(meta.resourceMapping) != 0 {
-			if entity, ok := meta.resourceMapping[strings.ToUpper(res.AzureId.String())]; ok {
+		m := resmap.ResourceMapping{}
+		for k, v := range meta.resourceMapping {
+			m[strings.ToUpper(k)] = v
+		}
+
+		if len(m) != 0 {
+			if entity, ok := m[strings.ToUpper(res.AzureId.String())]; ok {
 				item.TFResourceId = entity.ResourceId
 				item.TFAddr = tfaddr.TFAddr{
 					Type: entity.ResourceType,

--- a/internal/run.go
+++ b/internal/run.go
@@ -77,6 +77,16 @@ func ResourceImport(ctx context.Context, cfg config.ResConfig) error {
 			l = append(l, item)
 		}
 
+		msg.SetStatus("Exporting Resource Mapping file...")
+		if err := c.ExportResourceMapping(l); err != nil {
+			return fmt.Errorf("exporting Resource Mapping file: %v", err)
+		}
+
+		// Return early if only generating mapping file
+		if cfg.GenerateMappingFile {
+			return nil
+		}
+
 		msgs := []string{}
 		for _, item := range l {
 			msgs = append(msgs, fmt.Sprintf(`Resource Address: %s
@@ -133,6 +143,21 @@ func BatchImport(cfg config.GroupConfig, continueOnError bool) error {
 			return err
 		}
 
+		msg.SetStatus("Exporting Skipped Resource file...")
+		if err := c.ExportSkippedResources(list); err != nil {
+			return fmt.Errorf("exporting Skipped Resource file: %v", err)
+		}
+
+		msg.SetStatus("Exporting Resource Mapping file...")
+		if err := c.ExportResourceMapping(list); err != nil {
+			return fmt.Errorf("exporting Resource Mapping file: %v", err)
+		}
+
+		// Return early if only generating mapping file
+		if cfg.GenerateMappingFile {
+			return nil
+		}
+
 		msg.SetStatus("Importing resources...")
 		for i := range list {
 			if list[i].Skip() {
@@ -149,16 +174,6 @@ func BatchImport(cfg config.GroupConfig, continueOnError bool) error {
 				}
 				warnings = append(warnings, msg)
 			}
-		}
-
-		msg.SetStatus("Exporting Resource Mapping file...")
-		if err := c.ExportResourceMapping(list); err != nil {
-			return fmt.Errorf("exporting Resource Mapping file: %v", err)
-		}
-
-		msg.SetStatus("Exporting Skipped Resource file...")
-		if err := c.ExportSkippedResources(list); err != nil {
-			return fmt.Errorf("exporting Skipped Resource file: %v", err)
 		}
 
 		msg.SetStatus("Generating Terraform configurations...")

--- a/internal/run.go
+++ b/internal/run.go
@@ -53,7 +53,7 @@ func ResourceImport(ctx context.Context, cfg config.ResConfig) error {
 		rl := resourceSet.ToTFResources()
 
 		var l meta.ImportList
-		for i, res := range rl {
+		for _, res := range rl {
 			item := meta.ImportItem{
 				AzureResourceID: res.AzureId,
 				TFResourceId:    res.TFId, // this might be empty if have multiple matches in aztft
@@ -65,13 +65,15 @@ func ResourceImport(ctx context.Context, cfg config.ResConfig) error {
 
 			// Some special Azure resource is missing the essential property that is used by aztft to detect their TF resource type.
 			// In this case, users can use the `--type` option to manually specify the TF resource type.
-			if i == 0 && c.ResourceType != "" {
-				tfid, err := c.QueryResourceId(c.ResourceType)
-				if err != nil {
-					return err
+			if c.ResourceType != "" {
+				if c.AzureId.Equal(res.AzureId) {
+					tfid, err := c.QueryResourceId(c.ResourceType)
+					if err != nil {
+						return err
+					}
+					item.TFResourceId = tfid
+					item.TFAddr.Type = c.ResourceType
 				}
-				item.TFResourceId = tfid
-				item.TFAddr.Type = c.ResourceType
 			}
 
 			l = append(l, item)

--- a/internal/test/cases/case_applicationinsight_webtest.go
+++ b/internal/test/cases/case_applicationinsight_webtest.go
@@ -54,17 +54,17 @@ XML
 
 func (CaseApplicationInsightWebTest) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.insights/components/test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.insights/components/test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_application_insights",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Insights/components/test-%[3]s"
 },
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.insights/webtests/test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.insights/webtests/test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_application_insights_web_test",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Insights/webTests/test-%[3]s"

--- a/internal/test/cases/case_compute_vm_disk.go
+++ b/internal/test/cases/case_compute_vm_disk.go
@@ -90,43 +90,43 @@ resource "azurerm_virtual_machine_data_disk_attachment" "test" {
 
 func (CaseComputeVMDisk) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/disks/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/disks/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_managed_disk",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Compute/disks/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/virtualmachines/aztfy-test-%[3]s/datadisks/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/virtualmachines/aztfy-test-%[3]s/datadisks/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_virtual_machine_data_disk_attachment",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Compute/virtualMachines/aztfy-test-%[3]s/dataDisks/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/virtualmachines/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.compute/virtualmachines/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_linux_virtual_machine",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Compute/virtualMachines/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/networkinterfaces/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/networkinterfaces/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_network_interface",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/networkInterfaces/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_virtual_network",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfy-test-%[3]s/subnets/internal" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfy-test-%[3]s/subnets/internal" | Quote }}: {
   "resource_type": "azurerm_subnet",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfy-test-%[3]s/subnets/internal"

--- a/internal/test/cases/case_function_app_slot.go
+++ b/internal/test/cases/case_function_app_slot.go
@@ -61,31 +61,31 @@ resource "azurerm_windows_function_app_slot" "test" {
 
 func (CaseFunctionAppSlot) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfytest%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfytest%[3]s" | Quote }}: {
   "resource_type": "azurerm_storage_account",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Storage/storageAccounts/aztfytest%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/serverfarms/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/serverfarms/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_service_plan",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/serverfarms/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/sites/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/sites/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_windows_function_app",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/sites/aztfy-test-%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/sites/aztfy-test-%[3]s/slots/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.web/sites/aztfy-test-%[3]s/slots/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_windows_function_app_slot",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Web/sites/aztfy-test-%[3]s/slots/aztfy-test-%[3]s"

--- a/internal/test/cases/case_key_vault_nested_items.go
+++ b/internal/test/cases/case_key_vault_nested_items.go
@@ -181,31 +181,31 @@ func (c CaseKeyVaultNestedItems) ResourceMapping(d test.Data) (resmap.ResourceMa
 		return nil, err
 	}
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_key_vault",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.KeyVault/vaults/aztfy-test-%[3]s"
 },
 
-{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/keys/key-%[3]s" | ToUpper | Quote }} : {
+{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/keys/key-%[3]s" | Quote }} : {
   "resource_type": "azurerm_key_vault_key",
   "resource_name": "test",
   "resource_id": %[4]q
 },
 
-{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/secrets/secret-%[3]s" | ToUpper | Quote }} : {
+{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/secrets/secret-%[3]s" | Quote }} : {
   "resource_type": "azurerm_key_vault_secret",
   "resource_name": "test",
   "resource_id": %[5]q
 },
 
-{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/certificates/cert-%[3]s" | ToUpper | Quote }} : {
+{{  "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.keyvault/vaults/aztfy-test-%[3]s/certificates/cert-%[3]s" | Quote }} : {
   "resource_type": "azurerm_key_vault_certificate",
   "resource_name": "test",
   "resource_id": %[6]q

--- a/internal/test/cases/case_signalr_service.go
+++ b/internal/test/cases/case_signalr_service.go
@@ -39,13 +39,13 @@ resource "azurerm_signalr_service" "test" {
 
 func (CaseSignalRService) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.signalrservice/signalr/test-%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.signalrservice/signalr/test-%[3]s" | Quote }}: {
   "resource_type": "azurerm_signalr_service",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.SignalRService/signalR/test-%[3]s"

--- a/internal/test/cases/case_storage_file_share.go
+++ b/internal/test/cases/case_storage_file_share.go
@@ -43,19 +43,19 @@ resource "azurerm_storage_share" "test" {
 
 func (CaseStorageFileShare) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
 	return test.ResourceMapping(fmt.Sprintf(`{
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
   "resource_type": "azurerm_resource_group",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfy%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfy%[3]s" | Quote }}: {
   "resource_type": "azurerm_storage_account",
   "resource_name": "test",
   "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Storage/storageAccounts/aztfy%[3]s"
 },
 
-{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfy%[3]s/fileservices/default/shares/aztfy%[3]s" | ToUpper | Quote }}: {
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.storage/storageaccounts/aztfy%[3]s/fileservices/default/shares/aztfy%[3]s" | Quote }}: {
   "resource_type": "azurerm_storage_share",
   "resource_name": "test",
   "resource_id": "https://aztfy%[3]s.file.core.windows.net/aztfy%[3]s"

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -53,6 +53,8 @@ func (s status) String() string {
 		"importing",
 		"import error message",
 		"generating Terraform configuration",
+		"exporting resource mapping file",
+		"exporting skipped resources file",
 		"summary",
 		"quitting",
 		"error",

--- a/main.go
+++ b/main.go
@@ -25,15 +25,16 @@ import (
 func main() {
 	var (
 		// common flags
-		flagSubscriptionId string
-		flagOutputDir      string
-		flagOverwrite      bool
-		flagAppend         bool
-		flagDevProvider    bool
-		flagBackendType    string
-		flagBackendConfig  cli.StringSlice
-		flagFullConfig     bool
-		flagParallelism    int
+		flagSubscriptionId      string
+		flagOutputDir           string
+		flagOverwrite           bool
+		flagAppend              bool
+		flagDevProvider         bool
+		flagBackendType         string
+		flagBackendConfig       cli.StringSlice
+		flagFullConfig          bool
+		flagParallelism         int
+		flagGenerateMappingFile bool
 
 		// common flags (hidden)
 		hflagLogPath string
@@ -134,6 +135,13 @@ func main() {
 			Value:       10,
 			Destination: &flagParallelism,
 		},
+		&cli.BoolFlag{
+			Name:        "generate-mapping-file",
+			Aliases:     []string{"g"},
+			EnvVars:     []string{"AZTFY_GENERATE_MAPPING_FILE"},
+			Usage:       "In batch mode, only generate the resource mapping file, but DO NOT import any resource",
+			Destination: &flagGenerateMappingFile,
+		},
 
 		// Hidden flags
 		&cli.StringFlag{
@@ -172,7 +180,7 @@ func main() {
 			Name:        "continue",
 			EnvVars:     []string{"AZTFY_CONTINUE"},
 			Aliases:     []string{"k"},
-			Usage:       "Whether continue on import error (batch mode only)",
+			Usage:       "In batch mode, whether to continue on any import error",
 			Destination: &flagContinue,
 		},
 		&cli.StringFlag{
@@ -233,6 +241,9 @@ func main() {
 					if flagContinue && !flagBatchMode {
 						return fmt.Errorf("`--continue` must be used together with `--batch`")
 					}
+					if flagGenerateMappingFile && !flagBatchMode {
+						return fmt.Errorf("`--generate-mapping-file` must be used together with `--batch`")
+					}
 
 					predicate := c.Args().First()
 
@@ -259,16 +270,17 @@ func main() {
 					cfg := config.GroupConfig{
 						MockClient: hflagMockClient,
 						CommonConfig: config.CommonConfig{
-							SubscriptionId: subscriptionId,
-							OutputDir:      flagOutputDir,
-							Overwrite:      flagOverwrite,
-							Append:         flagAppend,
-							DevProvider:    flagDevProvider,
-							BackendType:    flagBackendType,
-							BackendConfig:  flagBackendConfig.Value(),
-							FullConfig:     flagFullConfig,
-							Parallelism:    flagParallelism,
-							PlainUI:        hflagPlainUI,
+							SubscriptionId:      subscriptionId,
+							OutputDir:           flagOutputDir,
+							Overwrite:           flagOverwrite,
+							Append:              flagAppend,
+							DevProvider:         flagDevProvider,
+							BackendType:         flagBackendType,
+							BackendConfig:       flagBackendConfig.Value(),
+							FullConfig:          flagFullConfig,
+							Parallelism:         flagParallelism,
+							PlainUI:             hflagPlainUI,
+							GenerateMappingFile: flagGenerateMappingFile,
 						},
 					}
 
@@ -324,6 +336,9 @@ func main() {
 					if flagContinue && !flagBatchMode {
 						return fmt.Errorf("`--continue` must be used together with `--batch`")
 					}
+					if flagGenerateMappingFile && !flagBatchMode {
+						return fmt.Errorf("`--generate-mapping-file` must be used together with `--batch`")
+					}
 
 					rg := c.Args().First()
 
@@ -350,16 +365,17 @@ func main() {
 					cfg := config.GroupConfig{
 						MockClient: hflagMockClient,
 						CommonConfig: config.CommonConfig{
-							SubscriptionId: subscriptionId,
-							OutputDir:      flagOutputDir,
-							Overwrite:      flagOverwrite,
-							Append:         flagAppend,
-							DevProvider:    flagDevProvider,
-							BackendType:    flagBackendType,
-							BackendConfig:  flagBackendConfig.Value(),
-							FullConfig:     flagFullConfig,
-							Parallelism:    flagParallelism,
-							PlainUI:        hflagPlainUI,
+							SubscriptionId:      subscriptionId,
+							OutputDir:           flagOutputDir,
+							Overwrite:           flagOverwrite,
+							Append:              flagAppend,
+							DevProvider:         flagDevProvider,
+							BackendType:         flagBackendType,
+							BackendConfig:       flagBackendConfig.Value(),
+							FullConfig:          flagFullConfig,
+							Parallelism:         flagParallelism,
+							PlainUI:             hflagPlainUI,
+							GenerateMappingFile: flagGenerateMappingFile,
 						},
 					}
 
@@ -456,17 +472,18 @@ func main() {
 					// Initialize the config
 					cfg := config.ResConfig{
 						CommonConfig: config.CommonConfig{
-							SubscriptionId: subscriptionId,
-							OutputDir:      flagOutputDir,
-							Overwrite:      flagOverwrite,
-							Append:         flagAppend,
-							DevProvider:    flagDevProvider,
-							BatchMode:      true,
-							BackendType:    flagBackendType,
-							BackendConfig:  flagBackendConfig.Value(),
-							FullConfig:     flagFullConfig,
-							Parallelism:    flagParallelism,
-							PlainUI:        hflagPlainUI,
+							SubscriptionId:      subscriptionId,
+							OutputDir:           flagOutputDir,
+							Overwrite:           flagOverwrite,
+							Append:              flagAppend,
+							DevProvider:         flagDevProvider,
+							BatchMode:           true,
+							BackendType:         flagBackendType,
+							BackendConfig:       flagBackendConfig.Value(),
+							FullConfig:          flagFullConfig,
+							Parallelism:         flagParallelism,
+							PlainUI:             hflagPlainUI,
+							GenerateMappingFile: flagGenerateMappingFile,
 						},
 						ResourceId:   resId,
 						ResourceName: flagName,


### PR DESCRIPTION
Related to #222

- In batch mode for `rg` and `query`, and also for `res`, `-g` will only generate resouce maping file, but not import any resource (interactive mode already has <kbd>s</kbd> for the same purpose)
- Remove the prefix dot of the resource mapping file and skipped resouces file names, to make it noticebale for Linux/Mac users
- `res` mode now also exports resource mapping file on a successful run (as a single azure resource might ends up with multiple TF resources)
- Making the key of resource mapping file case sensitive (to make the key usable for res mode)