### PR TITLE
New option: `--hcl-only` to only keep the .tf files in the output directory, and removing the others

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type CommonConfig struct {
 	Parallelism         int
 	PlainUI             bool
 	GenerateMappingFile bool
+	HCLOnly             bool
 }
 
 type Config struct {

--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -71,3 +71,8 @@ func (m MetaGroupDummy) ExportSkippedResources(l ImportList) error {
 	time.Sleep(500 * time.Millisecond)
 	return nil
 }
+
+func (m MetaGroupDummy) CleanUpWorkspace() error {
+	time.Sleep(500 * time.Millisecond)
+	return nil
+}

--- a/internal/run.go
+++ b/internal/run.go
@@ -68,6 +68,11 @@ func BatchImport(cfg config.Config) error {
 			return fmt.Errorf("generating Terraform configuration: %v", err)
 		}
 
+		msg.SetStatus("Cleaning up the output directory to only keep the .tf files...")
+		if err := c.CleanUpWorkspace(); err != nil {
+			return fmt.Errorf("cleaning up the output directory to only keep the .tf files: %v", err)
+		}
+
 		return nil
 	}
 

--- a/internal/ui/aztfyclient/client.go
+++ b/internal/ui/aztfyclient/client.go
@@ -46,6 +46,8 @@ type ExportSkippedResourcesDoneMsg struct {
 
 type GenerateCfgDoneMsg struct{}
 
+type WorkspaceCleanupDoneMsg struct{}
+
 type QuitMsg struct{}
 
 type CleanTFStateMsg struct {
@@ -114,6 +116,15 @@ func GenerateCfg(c meta.Meta, l meta.ImportList) tea.Cmd {
 			return ErrMsg(err)
 		}
 		return GenerateCfgDoneMsg{}
+	}
+}
+
+func CleanUpWorkspace(c meta.Meta) tea.Cmd {
+	return func() tea.Msg {
+		if err := c.CleanUpWorkspace(); err != nil {
+			return ErrMsg(err)
+		}
+		return WorkspaceCleanupDoneMsg{}
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -38,6 +38,7 @@ const (
 	statusImporting
 	statusImportErrorMsg
 	statusGeneratingCfg
+	statusCleaningUpWorkspaceCfg
 	statusExportResourceMapping
 	statusExportSkippedResources
 	statusSummary
@@ -53,6 +54,7 @@ func (s status) String() string {
 		"importing",
 		"import error message",
 		"generating Terraform configuration",
+		"cleaning up output directory",
 		"exporting resource mapping file",
 		"exporting skipped resources file",
 		"summary",
@@ -162,6 +164,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.status = statusGeneratingCfg
 		return m, aztfyclient.GenerateCfg(m.meta, msg.List)
 	case aztfyclient.GenerateCfgDoneMsg:
+		m.status = statusCleaningUpWorkspaceCfg
+		return m, aztfyclient.CleanUpWorkspace(m.meta)
+	case aztfyclient.WorkspaceCleanupDoneMsg:
 		m.status = statusSummary
 		return m, nil
 	case aztfyclient.QuitMsg:
@@ -217,12 +222,14 @@ func (m model) View() string {
 		s += importErrorView(m)
 	case statusImporting:
 		s += m.spinner.View() + m.progress.View()
-	case statusGeneratingCfg:
-		s += m.spinner.View() + " Generating Terraform Configurations..."
 	case statusExportResourceMapping:
 		s += m.spinner.View() + " Exporting Resource Mapping..."
 	case statusExportSkippedResources:
 		s += m.spinner.View() + " Exporting Skipped Resources..."
+	case statusGeneratingCfg:
+		s += m.spinner.View() + " Generating Terraform Configurations..."
+	case statusCleaningUpWorkspaceCfg:
+		s += m.spinner.View() + " Cleaning up the output directory..."
 	case statusSummary:
 		s += summaryView(m)
 	case statusError:

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		flagContinue            bool
 		flagNonInteractive      bool
 		flagGenerateMappingFile bool
+		flagHCLOnly             bool
 
 		// common flags (hidden)
 		hflagMockClient bool
@@ -76,6 +77,14 @@ func main() {
 			}
 			if flagGenerateMappingFile {
 				return fmt.Errorf("`--generate-mapping-file` must be used together with `--non-interactive`")
+			}
+		}
+		if flagHCLOnly {
+			if flagBackendType != "local" {
+				return fmt.Errorf("`--hcl-only` only works for local backend")
+			}
+			if flagAppend {
+				return fmt.Errorf("`--appned` conflicts with `--hcl-only`")
 			}
 		}
 
@@ -181,6 +190,12 @@ func main() {
 			EnvVars:     []string{"AZTFY_GENERATE_MAPPING_FILE"},
 			Usage:       "Only generate the resource mapping file, but DO NOT import any resource",
 			Destination: &flagGenerateMappingFile,
+		},
+		&cli.BoolFlag{
+			Name:        "hcl-only",
+			EnvVars:     []string{"AZTFY_HCL_ONLY"},
+			Usage:       "Only generate HCL code, but not the files for resource management (e.g. the state file)",
+			Destination: &flagHCLOnly,
 		},
 
 		// Hidden flags
@@ -292,6 +307,7 @@ func main() {
 							Parallelism:         flagParallelism,
 							PlainUI:             hflagPlainUI,
 							GenerateMappingFile: flagGenerateMappingFile,
+							HCLOnly:             flagHCLOnly,
 						},
 						ResourceId:     resId,
 						TFResourceName: flagResName,
@@ -336,6 +352,7 @@ func main() {
 							Parallelism:         flagParallelism,
 							PlainUI:             hflagPlainUI,
 							GenerateMappingFile: flagGenerateMappingFile,
+							HCLOnly:             flagHCLOnly,
 						},
 						ResourceGroupName:   rg,
 						ResourceNamePattern: flagPattern,
@@ -379,6 +396,7 @@ func main() {
 							Parallelism:         flagParallelism,
 							PlainUI:             hflagPlainUI,
 							GenerateMappingFile: flagGenerateMappingFile,
+							HCLOnly:             flagHCLOnly,
 						},
 						ARGPredicate:        predicate,
 						ResourceNamePattern: flagPattern,
@@ -422,6 +440,7 @@ func main() {
 							Parallelism:         flagParallelism,
 							PlainUI:             hflagPlainUI,
 							GenerateMappingFile: flagGenerateMappingFile,
+							HCLOnly:             flagHCLOnly,
 						},
 						MappingFile: mapFile,
 					}


### PR DESCRIPTION
New option: `--hcl-only` to only keep the .tf files in the output directory, and removing the other files (e.g. state file).

Relating to #222 