### PR TITLE
Handle multiple azure resources have the same TF id when resolving TF dependency

### DIFF
--- a/internal/meta/config_info.go
+++ b/internal/meta/config_info.go
@@ -16,8 +16,12 @@ type ConfigInfos []ConfigInfo
 
 type ConfigInfo struct {
 	ImportItem
-	DependsOn []string // Azure resource ids
+	DependsOn []Dependency
 	hcl       *hclwrite.File
+}
+
+type Dependency struct {
+	Candidates []string
 }
 
 func (cfg ConfigInfo) DumpHCL(w io.Writer) (int, error) {
@@ -37,10 +41,15 @@ func (cfgs ConfigInfos) AddDependency() error {
 			continue
 		}
 
-		// Disduplicate same resource ids
+		// Disduplicate same resource ids that has exact one candidate
 		set := map[string]bool{}
+		duplicates := []Dependency{}
 		for _, dep := range cfg.DependsOn {
-			set[dep] = true
+			if len(dep.Candidates) == 1 {
+				set[dep.Candidates[0]] = true
+			} else {
+				duplicates = append(duplicates, dep)
+			}
 		}
 
 		// Disduplicate dependency that is parent of another dependency
@@ -60,14 +69,39 @@ func (cfgs ConfigInfos) AddDependency() error {
 			delete(set, dep)
 		}
 
-		// Sort the dependencies
-		cfg.DependsOn = []string{}
+		// If all duplicate candidates are child of this dependency, then also remove it.
+		covlist = []string{}
 		for dep := range set {
-			cfg.DependsOn = append(cfg.DependsOn, dep)
+			for _, odep := range duplicates {
+				allIsChild := true
+				for _, candidate := range odep.Candidates {
+					if !strings.HasPrefix(strings.ToUpper(candidate), strings.ToUpper(dep)) {
+						allIsChild = false
+						break
+					}
+				}
+				if allIsChild {
+					covlist = append(covlist, dep)
+					break
+				}
+			}
+		}
+		for _, dep := range covlist {
+			delete(set, dep)
 		}
 
+		// Sort the dependencies
+		cfg.DependsOn = duplicates
+		for id := range set {
+			id := id
+			cfg.DependsOn = append(cfg.DependsOn, Dependency{Candidates: []string{id}})
+		}
 		sort.Slice(cfg.DependsOn, func(i, j int) bool {
-			return cfg.DependsOn[i] < cfg.DependsOn[j]
+			d1, d2 := cfg.DependsOn[i], cfg.DependsOn[j]
+			if len(d1.Candidates) != len(d2.Candidates) {
+				return len(d1.Candidates) < len(d2.Candidates)
+			}
+			return strings.Join(d1.Candidates, "") < strings.Join(d2.Candidates, "")
 		})
 		cfgs[i] = cfg
 	}
@@ -94,7 +128,8 @@ func (cfgs ConfigInfos) addParentChildDependency() {
 				continue
 			}
 			if parentId.Equal(ocfg.AzureResourceID) {
-				cfg.DependsOn = []string{ocfg.AzureResourceID.String()}
+				id := ocfg.AzureResourceID.String()
+				cfg.DependsOn = []Dependency{{Candidates: []string{id}}}
 				cfgs[i] = cfg
 				break
 			}
@@ -103,10 +138,12 @@ func (cfgs ConfigInfos) addParentChildDependency() {
 }
 
 func (cfgs ConfigInfos) addReferenceDependency() error {
-	// TODO: we shall consider a TF resource and its child resource have the same TF id?
-	m := map[string]string{} // TF resource id to Azure resource id
+	// TF resource id to Azure resource ids.
+	// Typically, one TF resource id maps to one Azure resource id. However, there are cases that one one TF resource id maps to multiple Azure resource ids.
+	// E.g. A parent and child resources have the same TF id. Or the association resource's TF id is the same as the master resource's.
+	m := map[string][]string{}
 	for _, cfg := range cfgs {
-		m[cfg.TFResourceId] = cfg.AzureResourceID.String()
+		m[cfg.TFResourceId] = append(m[cfg.TFResourceId], cfg.AzureResourceID.String())
 	}
 
 	for i, cfg := range cfgs {
@@ -126,11 +163,19 @@ func (cfgs ConfigInfos) addReferenceDependency() error {
 			maybeTFId := val.AsString()
 
 			// This is safe to match case sensitively given the TF id are consistent across the provider. Otherwise, it is a provider bug.
-			dependingResourceId, ok := m[maybeTFId]
+			dependingResourceIds, ok := m[maybeTFId]
 			if !ok {
 				return nil
 			}
-			cfg.DependsOn = append(cfg.DependsOn, dependingResourceId)
+
+			var dependingResourceIdsWithoutSelf []string
+			for _, id := range dependingResourceIds[:] {
+				if id == cfg.AzureResourceID.String() {
+					continue
+				}
+				dependingResourceIdsWithoutSelf = append(dependingResourceIdsWithoutSelf, id)
+			}
+			cfg.DependsOn = append(cfg.DependsOn, Dependency{Candidates: dependingResourceIdsWithoutSelf})
 			return nil
 		})
 		cfgs[i] = cfg


### PR DESCRIPTION
There are cases that multiple Azure resources correspond to the same TF resource id. E.g. parent and child resources, or an association resource and its master resource. In this case, when resolving cross resource dependencies, as we are depending on the TF resource id, we will ends up with multiple TF resources. There is no good way to tell which one of them is the exact depended resource. The only right thing to do is to add a comment containing all the candidates and let users to choose.