### PR TITLE
Avoid adding dependency when no cross reference exists

### DIFF
--- a/internal/meta/config_info.go
+++ b/internal/meta/config_info.go
@@ -175,7 +175,9 @@ func (cfgs ConfigInfos) addReferenceDependency() error {
 				}
 				dependingResourceIdsWithoutSelf = append(dependingResourceIdsWithoutSelf, id)
 			}
-			cfg.DependsOn = append(cfg.DependsOn, Dependency{Candidates: dependingResourceIdsWithoutSelf})
+			if len(dependingResourceIdsWithoutSelf) != 0 {
+				cfg.DependsOn = append(cfg.DependsOn, Dependency{Candidates: dependingResourceIdsWithoutSelf})
+			}
 			return nil
 		})
 		cfgs[i] = cfg


### PR DESCRIPTION
Avoid adding dependency when no cross reference exists, which avoid a panic when later adding dependencies to the HCL.

The way to reproduce this issue is to only import a subnet NSG association resource.