### PR TITLE
Avoid using `os.Rename()`

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -284,10 +284,10 @@ func (meta baseMeta) CleanUpWorkspace() error {
 	tmpMainCfg := filepath.Join(tmpDir, meta.filenameMainCfg())
 	tmpProviderCfg := filepath.Join(tmpDir, meta.filenameProviderSetting())
 
-	if err := os.Rename(filepath.Join(meta.Workspace(), meta.filenameMainCfg()), tmpMainCfg); err != nil {
+	if err := utils.CopyFile(filepath.Join(meta.Workspace(), meta.filenameMainCfg()), tmpMainCfg); err != nil {
 		return err
 	}
-	if err := os.Rename(filepath.Join(meta.Workspace(), meta.filenameProviderSetting()), tmpProviderCfg); err != nil {
+	if err := utils.CopyFile(filepath.Join(meta.Workspace(), meta.filenameProviderSetting()), tmpProviderCfg); err != nil {
 		return err
 	}
 
@@ -295,10 +295,10 @@ func (meta baseMeta) CleanUpWorkspace() error {
 		return err
 	}
 
-	if err := os.Rename(tmpMainCfg, filepath.Join(meta.Workspace(), meta.filenameMainCfg())); err != nil {
+	if err := utils.CopyFile(tmpMainCfg, filepath.Join(meta.Workspace(), meta.filenameMainCfg())); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpProviderCfg, filepath.Join(meta.Workspace(), meta.filenameProviderSetting())); err != nil {
+	if err := utils.CopyFile(tmpProviderCfg, filepath.Join(meta.Workspace(), meta.filenameProviderSetting())); err != nil {
 		return err
 	}
 

--- a/internal/utils/copyfile.go
+++ b/internal/utils/copyfile.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+func CopyFile(src, dst string) error {
+	stat, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stating source file %s: %v", src, err)
+	}
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("reading from %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, b, stat.Mode()); err != nil {
+		return fmt.Errorf("writing to %s: %v", dst, err)
+	}
+	return nil
+}


### PR DESCRIPTION
`os.Rename()` doesn't work for Windows when moving files across drives. Copy by bytes instead.

Fix #267 