### PR TITLE
Don't merge state if import error in parallel import

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -245,6 +245,12 @@ func (meta *baseMeta) ParallelImport(items []*ImportItem) {
 
 	wp.Run(func(i interface{}) error {
 		idx := i.(int)
+
+		// Don't merge state if import error hit
+		if items[idx].ImportError != nil {
+			return nil
+		}
+
 		stateFile := filepath.Join(meta.importDirs[idx], "terraform.tfstate")
 
 		// Ensure the state file is removed after this round import, preparing for the next round.


### PR DESCRIPTION
Don't merge state if import error in parallel import, which reveals the import error message in UI.