### PR TITLE
Add WinGet Releaser

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -637,18 +637,10 @@ stages:
       - job: pr
         displayName: "PR to winget"
         steps:
-          - pwsh: |
-              $ErrorActionPreference = "Stop"
-
-              cd
-              iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-              git clone https://github.com/microsoft/winget-pkgs.git
-              cd winget-pkgs
-              ..\wingetcreate.exe update --urls https://github.com/Azure/aztfy/releases/download/$env:VERSION/aztfy_$($env:VERSION)_x64.msi --version $env:VERSION.Substring(1) --submit --token $env:PAT Microsoft.AzureAztfy
-            displayName: "Create PR"
-            env:
-              VERSION: ${{ parameters.version }}
-              PAT: $(AZURE_TERRAFORM_BOT_PAT)
+          - uses: vedantmgoyal2009/winget-releaser@v1
+            with:
+              identifier: Microsoft.AzureAztfy
+              token: ${{ secrets.AZURE_TERRAFORM_BOT_PAT }}
 
   - stage: pr_to_homebrew
     displayName: "PR to homebrew"


### PR DESCRIPTION
This PR replaces the publishing of aztfy to WinGet with [WinGet Releaser](https://github.com/vedantmgoyal2009/winget-releaser) rather than wingetcreate.

The use of WinGet Releaser over a custom script has lots of added benefits, such as greater maintainability and more developed manifests, as WinGet Releaser is able to pull more data from GitHub Releases, like release date, release notes, etc.

As an example, here is a pull request for Vim that uses WinGet Releaser: https://github.com/microsoft/winget-pkgs/pull/88554

Tagging @vedantmgoyal2009