### PR TITLE
Move the interactive output dir check code from `NewBaseMeta()` to CLI before function

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ type CommonConfig struct {
 	LogPath             string
 	SubscriptionId      string
 	OutputDir           string
-	Overwrite           bool
 	Append              bool
 	DevProvider         bool
 	Batch               bool

--- a/internal/test/query/query_test.go
+++ b/internal/test/query/query_test.go
@@ -90,13 +90,15 @@ resource "azurerm_subnet" "test" {
 			BackendType:    "local",
 			DevProvider:    true,
 			PlainUI:        true,
-			Overwrite:      true,
 			Parallelism:    1,
 		},
 		ResourceNamePattern: "res-",
 		ARGPredicate:        fmt.Sprintf(`resourceGroup =~ "%s" and type =~ "microsoft.network/virtualnetworks"`, d.RandomRgName()),
 	}
 	t.Log("Importing in non-recursive mode")
+	if err := utils.RemoveEverythingUnder(cfg.OutputDir); err != nil {
+		t.Fatalf("failed to clean up the output directory: %v", err)
+	}
 	if err := internal.BatchImport(cfg); err != nil {
 		t.Fatalf("failed to run batch import non-recursively: %v", err)
 	}
@@ -104,9 +106,10 @@ resource "azurerm_subnet" "test" {
 
 	// Import in recursive mode
 	t.Log("Importing in recursive mode")
-	// aztfyDir = t.TempDir()
-	// cfg.CommonConfig.OutputDir = aztfyDir
 	cfg.RecursiveQuery = true
+	if err := utils.RemoveEverythingUnder(cfg.OutputDir); err != nil {
+		t.Fatalf("failed to clean up the output directory: %v", err)
+	}
 	if err := internal.BatchImport(cfg); err != nil {
 		t.Fatalf("failed to run batch import recursively: %v", err)
 	}

--- a/internal/test/resource/e2e_cases_test.go
+++ b/internal/test/resource/e2e_cases_test.go
@@ -68,13 +68,15 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 				BackendType:    "local",
 				DevProvider:    true,
 				PlainUI:        true,
-				Overwrite:      true,
 				Parallelism:    1,
 			},
 			ResourceId:     rctx.AzureId,
 			TFResourceName: fmt.Sprintf("res-%d", idx),
 		}
 		t.Logf("Resource importing %s\n", rctx.AzureId)
+		if err := utils.RemoveEverythingUnder(cfg.OutputDir); err != nil {
+			t.Fatalf("failed to clean up the output directory: %v", err)
+		}
 		if err := internal.BatchImport(cfg); err != nil {
 			t.Fatalf("failed to run resource import: %v", err)
 		}

--- a/internal/test/resourcegroup/append_test.go
+++ b/internal/test/resourcegroup/append_test.go
@@ -89,6 +89,9 @@ resource "azurerm_resource_group" "test3" {
 	cfg.ResourceGroupName = d.RandomRgName() + "1"
 	cfg.ResourceNamePattern = "round1_"
 	t.Log("Batch importing the 1st rg")
+	if err := utils.RemoveEverythingUnder(cfg.OutputDir); err != nil {
+		t.Fatalf("failed to clean up the output directory: %v", err)
+	}
 	if err := internal.BatchImport(cfg); err != nil {
 		t.Fatalf("failed to run first batch import: %v", err)
 	}

--- a/internal/utils/dir_is_empty.go
+++ b/internal/utils/dir_is_empty.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func DirIsEmpty(path string) (bool, error) {
+	stat, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, fmt.Errorf("the path %q doesn't exist", path)
+	}
+	if !stat.IsDir() {
+		return false, fmt.Errorf("the path %q is not a directory", path)
+	}
+	// #nosec G304
+	dir, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	_, err = dir.Readdirnames(1)
+	if err != nil {
+		if err == io.EOF {
+			if err := dir.Close(); err != nil {
+				return false, fmt.Errorf("closing dir %s: %v", path, err)
+			}
+			return true, nil
+		}
+		return false, err
+	}
+	if err := dir.Close(); err != nil {
+		return false, fmt.Errorf("closing dir %s: %v", path, err)
+	}
+	return false, nil
+}

--- a/internal/utils/remove_everything.go
+++ b/internal/utils/remove_everything.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func RemoveEverythingUnder(path string) error {
+	// #nosec G304
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s: %v", path, err)
+	}
+	entries, _ := dir.Readdirnames(0)
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(path, entry)); err != nil {
+			return fmt.Errorf("failed to remove %s: %v", entry, err)
+		}
+	}
+	if err := dir.Close(); err != nil {
+		return fmt.Errorf("closing dir %s: %v", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Moving the interactive output dir check code from `NewBaseMeta()` to CLI before function as the `NewBaseMeta()` is meant to be used by 3rd-party modules, which is inappropriate to hold code requires user's interactions.