### PR TITLE
Fix the incorrect tfmerge version during a merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
 	github.com/magodo/tfadd v0.10.1-0.20230106064825-378b3ebb9a4e
-	github.com/magodo/tfmerge v0.0.0-20221013065654-ba642eeb309a
+	github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402
 	github.com/magodo/workerpool v0.0.0-20211124060943-1c48f3e5a514
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0/go.mod h1:MqYhNP+PC386Bjsx5piZe7T4vDm5QIPv8b1RU0prVnU=
 github.com/magodo/tfadd v0.10.1-0.20230106064825-378b3ebb9a4e h1:EywN5T4ZF02ImRXEVkW6BmRcqsPgesn6EPJoPKMT60k=
 github.com/magodo/tfadd v0.10.1-0.20230106064825-378b3ebb9a4e/go.mod h1:DbJnYhmAkyjNnVt819cytTfJMtv5DpqV9MkHuUbyv3c=
-github.com/magodo/tfmerge v0.0.0-20221013065654-ba642eeb309a h1:3ldVIfIeVk4ipPwmG54MXr5IEjRNenv4ltxvMprKQF4=
-github.com/magodo/tfmerge v0.0.0-20221013065654-ba642eeb309a/go.mod h1:ssV++b4DH33rsD592bvpS4Peng3ZfdGNZbFgCDkCfj8=
+github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402 h1:RyaR4VE7hoR9AyoVH414cpM8V63H4rLe2aZyKdoDV1w=
+github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402/go.mod h1:ssV++b4DH33rsD592bvpS4Peng3ZfdGNZbFgCDkCfj8=
 github.com/magodo/tfpluginschema v0.0.0-20220905090502-2d6a05ebaefd h1:L0kTduNwpx60EdBPYOVF9oUY7jdfZHIncvQN490qWd4=
 github.com/magodo/tfpluginschema v0.0.0-20220905090502-2d6a05ebaefd/go.mod h1:u625f3VQoOZTAxoDjeDLmrBdKqriRK4OHCpSWt7FQc8=
 github.com/magodo/tfstate v0.0.0-20220409052014-9b9568dda918 h1:yZ5ZEMSKZNCM7KpivKhDNNQEZYSDxg0Wyi5p0hQ8dVo=


### PR DESCRIPTION
Fix the incorrect tfmerge version being used during the merge of #322: https://github.com/Azure/aztfy/pull/322/commits/61129a9ae3a73435ba8a7039c5d8e6b1008fcdf6#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R26

## Test

```shell
💤  AZTFY_E2E=1 go test -timeout=30m -run=TestAppendToModule ./internal/test/resourcegroup/... 
ok      github.com/Azure/aztfy/internal/test/resourcegroup      42.544s
```