### PR TITLE
Optimize state merging process when there is no base state given

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,7 @@ yay -S aztfy
 
 ## Precondition
 
-There is no special precondtion needed for running `aztfy`, except that you have access to Azure.
-
-Although `aztfy` depends on `terraform`, it is not required to have `terraform` pre-installed and configured in the [`PATH`](https://en.wikipedia.org/wiki/PATH_(variable)) before running `aztfy`. `aztfy` will ensure a `terraform` in the following order: 
-
-- If there is already a `terraform` discovered in the `PATH` whose version `>= v0.12`, then use it
-- Otherwise, if there is already a `terraform` installed at the `aztfy` cache directory, then use it
-- Otherwise, install the latest `terraform` from Hashicorp's release to the `aztfy` cache directory
-
-(The `aztfy` cache directory is at: "[\<UserCacheDir\>](https://pkg.go.dev/os#UserCacheDir)/aztfy")
+`aztfy` requires a `terraform` executable installed in the `$PATH`, whose version `>= v0.12`.
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -80,10 +80,7 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,7 +150,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
-github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -308,6 +308,7 @@ func (meta *baseMeta) ParallelImport(ctx context.Context, items []*ImportItem) e
 		// We are updating the local thisBaseStateJSON here, will update it to the meta.baseState at the end of this function.
 		if len(meta.originBaseState) == 0 {
 			log.Printf("[DEBUG] Merging terraform state file %s (simple)", stateFile)
+			// #nosec G304
 			b, err := os.ReadFile(stateFile)
 			if err != nil {
 				return fmt.Errorf("failed to read state file: %v", err)

--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -56,9 +56,9 @@ func (m MetaGroupDummy) CleanTFState(_ context.Context, _ string) {
 	return
 }
 
-func (m MetaGroupDummy) ParallelImport(_ context.Context, items []*ImportItem) {
+func (m MetaGroupDummy) ParallelImport(_ context.Context, items []*ImportItem) error {
 	time.Sleep(time.Second)
-	return
+	return nil
 }
 
 func (m MetaGroupDummy) PushState(_ context.Context) error {

--- a/internal/meta/tfinstall_find.go
+++ b/internal/meta/tfinstall_find.go
@@ -5,25 +5,18 @@ import (
 
 	"github.com/hashicorp/go-version"
 	install "github.com/hashicorp/hc-install"
-	"github.com/hashicorp/hc-install/checkpoint"
 	"github.com/hashicorp/hc-install/fs"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/src"
 )
 
 // FindTerraform finds the path to the terraform executable.
-func FindTerraform(ctx context.Context, tfDir string) (string, error) {
+func FindTerraform(ctx context.Context) (string, error) {
 	i := install.NewInstaller()
 	return i.Ensure(ctx, []src.Source{
 		&fs.Version{
 			Product:     product.Terraform,
-			ExtraPaths:  []string{tfDir},
 			Constraints: version.MustConstraints(version.NewConstraint(">=0.12")),
 		},
-		&checkpoint.LatestVersion{
-			Product:    product.Terraform,
-			InstallDir: tfDir,
-		},
 	})
-
 }

--- a/internal/run.go
+++ b/internal/run.go
@@ -81,7 +81,9 @@ func BatchImport(ctx context.Context, cfg config.NonInteractiveModeConfig) error
 			}
 
 			msg.SetStatus(strings.Join(messages, "\n"))
-			c.ParallelImport(ctx, importList)
+			if err := c.ParallelImport(ctx, importList); err != nil {
+				return fmt.Errorf("parallel importing: %v", err)
+			}
 
 			var thisErrors []string
 			for j := 0; j < n; j++ {

--- a/internal/test/resourcegroup/append_test.go
+++ b/internal/test/resourcegroup/append_test.go
@@ -106,7 +106,6 @@ resource "azurerm_resource_group" "test3" {
 		t.Fatalf("failed to run first batch import: %v", err)
 	}
 	// Import the second resource group mutably
-	cfg.Append = true
 	cfg.ResourceGroupName = d.RandomRgName() + "2"
 	cfg.ResourceNamePattern = "round2_"
 	t.Log("Batch importing the 2nd rg")
@@ -114,7 +113,6 @@ resource "azurerm_resource_group" "test3" {
 		t.Fatalf("failed to run second batch import: %v", err)
 	}
 	// Import the third resource group mutably
-	cfg.Append = true
 	cfg.ResourceGroupName = d.RandomRgName() + "3"
 	cfg.ResourceNamePattern = "round3_"
 	t.Log("Batch importing the 3rd rg")

--- a/internal/test/resourcegroup/module_test.go
+++ b/internal/test/resourcegroup/module_test.go
@@ -118,7 +118,6 @@ module "sub-module" {
 				BackendType:          "local",
 				DevProvider:          true,
 				Parallelism:          1,
-				Append:               true,
 				ModulePath:           "", // Import to the root module
 			},
 		},

--- a/internal/ui/aztfyclient/client.go
+++ b/internal/ui/aztfyclient/client.go
@@ -2,6 +2,7 @@ package aztfyclient
 
 import (
 	"context"
+
 	"github.com/Azure/aztfy/pkg/meta"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -104,7 +105,9 @@ func ImportItems(ctx context.Context, c meta.Meta, items []meta.ImportItem) tea.
 			}
 			l = append(l, &items[i])
 		}
-		c.ParallelImport(ctx, l)
+		if err := c.ParallelImport(ctx, l); err != nil {
+			return ErrMsg(err)
+		}
 		return ImportItemsDoneMsg{Items: items}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -348,6 +348,12 @@ The output directory is not empty. Please choose one of actions below:
 
 	mappingFileFlags := append([]cli.Flag{}, commonFlags...)
 
+	safeOutputFileNames := config.OutputFileNames{
+		TerraformFileName: "terraform.aztfy.tf",
+		ProviderFileName:  "provider.aztfy.tf",
+		MainFileName:      "main.aztfy.tf",
+	}
+
 	app := &cli.App{
 		Name:      "aztfy",
 		Version:   getVersion(),
@@ -387,7 +393,6 @@ The output directory is not empty. Please choose one of actions below:
 							AzureSDKCredential:   cred,
 							AzureSDKClientOption: *clientOpt,
 							OutputDir:            flagOutputDir,
-							Append:               flagAppend,
 							DevProvider:          flagDevProvider,
 							ContinueOnError:      flagContinue,
 							BackendType:          flagBackendType,
@@ -400,6 +405,10 @@ The output directory is not empty. Please choose one of actions below:
 						ResourceId:     resId,
 						TFResourceName: flagResName,
 						TFResourceType: flagResType,
+					}
+
+					if flagAppend {
+						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
 					return realMain(c.Context, cfg, flagNonInteractive, hflagMockClient, hflagPlainUI, flagGenerateMappingFile)
@@ -434,7 +443,6 @@ The output directory is not empty. Please choose one of actions below:
 							AzureSDKCredential:   cred,
 							AzureSDKClientOption: *clientOpt,
 							OutputDir:            flagOutputDir,
-							Append:               flagAppend,
 							DevProvider:          flagDevProvider,
 							ContinueOnError:      flagContinue,
 							BackendType:          flagBackendType,
@@ -447,6 +455,10 @@ The output directory is not empty. Please choose one of actions below:
 						ResourceGroupName:   rg,
 						ResourceNamePattern: flagPattern,
 						RecursiveQuery:      true,
+					}
+
+					if flagAppend {
+						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
 					return realMain(c.Context, cfg, flagNonInteractive, hflagMockClient, hflagPlainUI, flagGenerateMappingFile)
@@ -480,7 +492,6 @@ The output directory is not empty. Please choose one of actions below:
 							AzureSDKCredential:   cred,
 							AzureSDKClientOption: *clientOpt,
 							OutputDir:            flagOutputDir,
-							Append:               flagAppend,
 							DevProvider:          flagDevProvider,
 							ContinueOnError:      flagContinue,
 							BackendType:          flagBackendType,
@@ -493,6 +504,10 @@ The output directory is not empty. Please choose one of actions below:
 						ARGPredicate:        predicate,
 						ResourceNamePattern: flagPattern,
 						RecursiveQuery:      flagRecursive,
+					}
+
+					if flagAppend {
+						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
 					return realMain(c.Context, cfg, flagNonInteractive, hflagMockClient, hflagPlainUI, flagGenerateMappingFile)
@@ -527,7 +542,6 @@ The output directory is not empty. Please choose one of actions below:
 							AzureSDKCredential:   cred,
 							AzureSDKClientOption: *clientOpt,
 							OutputDir:            flagOutputDir,
-							Append:               flagAppend,
 							DevProvider:          flagDevProvider,
 							ContinueOnError:      flagContinue,
 							BackendType:          flagBackendType,
@@ -538,6 +552,10 @@ The output directory is not empty. Please choose one of actions below:
 							ModulePath:           flagModulePath,
 						},
 						MappingFile: mapFile,
+					}
+
+					if flagAppend {
+						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
 					return realMain(c.Context, cfg, flagNonInteractive, hflagMockClient, hflagPlainUI, flagGenerateMappingFile)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
+type OutputFileNames struct {
+	// The filename for the generated "terraform.tf" (default)
+	TerraformFileName string
+	// The filename for the generated "provider.tf" (default)
+	ProviderFileName string
+	// The filename for the generated "main.tf" (default)
+	MainFileName string
+}
+
 type CommonConfig struct {
 	// SubscriptionId specifies the user's Azure subscription id.
 	SubscriptionId string
@@ -14,8 +23,8 @@ type CommonConfig struct {
 	AzureSDKClientOption arm.ClientOptions
 	// OutputDir specifies the Terraform working directory for aztfy to import resources and generate TF configs.
 	OutputDir string
-	// Append specifies whether this run is in append mode, in which case aztfy will generate some "safe" file name to avoid conflicts to usre's existing files.
-	Append bool
+	// OutputFileNames specifies the output terraform filenames
+	OutputFileNames OutputFileNames
 	// DevProvider specifies whether to use a development provider built locally rather than using a version pinned provider from official Terraform registry.
 	DevProvider bool
 	// ContinueOnError specifies whether continue the progress even hit an import error.


### PR DESCRIPTION
Previously, we were using `tfmerge` to merge the import state file and the base state file, by a per resource movement manner. This is fine in most cases. But there is still a space to improve the performance, when there is no base state given (i.e. not appending to an existing workspace). In this case, as long as the import items have no address conflicts (guaranteed by `aztfy`), it can safely merge the state files by simply appending (`resources` field). Also since this state file is a fresh new one, there is no special requirement on the `serial` and `lineage`.

This PR also makes some other less related changes to make it more intuitive for library users:

- Remove the rootdir (i.e. cache dir) creation from `NewMeta()`. The cache dir is only used to cache an auto-downloaded terraform binary. We now eliminate this behavior due to as a library, this method shall be thread-safe, and we try to avoid downloading behavior as possible. **As a result, `aztfy` now depends on a pre-installed `terraform` executable that is located at $PATH**. Hence mark this PR as a breaking-change.
- Move the import directories creation to `meta.Init()`, to make it match the tear-down operations in `meta.DeInit()`
- `Config` now replaces `.Append` by `.OutputFileNames` to be more clear