### PR TITLE
Avoid `terraform init` for import workspaces when `--dev-provider` is specified

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,8 @@ type CommonConfig struct {
 	OutputDir string
 	// OutputFileNames specifies the output terraform filenames
 	OutputFileNames OutputFileNames
-	// DevProvider specifies whether to use a development provider built locally rather than using a version pinned provider from official Terraform registry.
+	// DevProvider specifies whether users have configured the `dev_overrides` for the provider, which then uses a development provider built locally rather than using a version pinned provider from official Terraform registry.
+	// Meanwhile, it will also avoid running `terraform init` during `Init()` for the import directories to avoid caculating the provider hash and populating the lock file (See: https://developer.hashicorp.com/terraform/language/files/dependency-lock). Though the init for the output directory is still needed for initializing the backend.
 	DevProvider bool
 	// ContinueOnError specifies whether continue the progress even hit an import error.
 	ContinueOnError bool


### PR DESCRIPTION
For environment that has `dev_overrides` correctly setup for the providers, users can use `--dev-provider` to indicate instead of using the pinned version, use the local dev provider. Another effect of using `dev_overrides` is that it will not check the dependency lock for each terraform command, hence avoid calculating the provider hash everytime. This saves us a bit of CPU time, especially we are running `terraform` commands in parallel.

Therefore, this PR extends the `--dev-provider` a bit to not only remove the version constraint in the `terraform.tf`, it will also avoid the `terraform init` for the import directories, as the follow up terraform command will not use that file at all (given `dev_overrides`). This saves us some CPU time during `Init()`.