### PR TITLE
Fix `--append` leaks to be used together with `--hcl-only` in interactive mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,6 +227,9 @@ The output directory is not empty. Please choose one of actions below:
 						return err
 					}
 				case "n":
+					if flagHCLOnly {
+						return fmt.Errorf("`--hcl-only` can only run within an empty directory")
+					}
 					flagAppend = true
 				default:
 					return fmt.Errorf("the output directory %q is not empty", flagOutputDir)


### PR DESCRIPTION
`--hcl-only` is not expected to be used together with `--append` as it should not impact user's existing states. But in interactive mode, when usres press `N`, current implementation will leak in.