### PR TITLE
Keep resource mapping file and skipped resource file in hcl only mode

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -497,11 +497,19 @@ func (meta baseMeta) CleanUpWorkspace(_ context.Context) error {
 
 		tmpMainCfg := filepath.Join(tmpDir, meta.outputFileNames.MainFileName)
 		tmpProviderCfg := filepath.Join(tmpDir, meta.outputFileNames.ProviderFileName)
+		tmpResourceMappingFileName := filepath.Join(tmpDir, ResourceMappingFileName)
+		tmpSkippedResourcesFileName := filepath.Join(tmpDir, SkippedResourcesFileName)
 
 		if err := utils.CopyFile(filepath.Join(meta.outdir, meta.outputFileNames.MainFileName), tmpMainCfg); err != nil {
 			return err
 		}
 		if err := utils.CopyFile(filepath.Join(meta.outdir, meta.outputFileNames.ProviderFileName), tmpProviderCfg); err != nil {
+			return err
+		}
+		if err := utils.CopyFile(filepath.Join(meta.outdir, ResourceMappingFileName), tmpResourceMappingFileName); err != nil {
+			return err
+		}
+		if err := utils.CopyFile(filepath.Join(meta.outdir, SkippedResourcesFileName), tmpSkippedResourcesFileName); err != nil {
 			return err
 		}
 
@@ -513,6 +521,12 @@ func (meta baseMeta) CleanUpWorkspace(_ context.Context) error {
 			return err
 		}
 		if err := utils.CopyFile(tmpProviderCfg, filepath.Join(meta.outdir, meta.outputFileNames.ProviderFileName)); err != nil {
+			return err
+		}
+		if err := utils.CopyFile(tmpResourceMappingFileName, filepath.Join(meta.outdir, ResourceMappingFileName)); err != nil {
+			return err
+		}
+		if err := utils.CopyFile(tmpSkippedResourcesFileName, filepath.Join(meta.outdir, SkippedResourcesFileName)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR keeps the `aztfyResourceMapping.json` and `aztfySkippedResources.txt` in `--hcl-only` mode. This is to allow users to use `--hcl-only` as a preview/plan to see what TF config will look like, and use the `aztfyResourceMapping.json` as the plan output, which can then be applied by `aztfy resmap` to do the real importing.