### PR TITLE
Test: suppress dev provider when running append to module test

### DIFF
--- a/internal/test/resourcegroup/module_test.go
+++ b/internal/test/resourcegroup/module_test.go
@@ -116,7 +116,6 @@ module "sub-module" {
 				AzureSDKClientOption: *clientOpt,
 				OutputDir:            aztfyDir,
 				BackendType:          "local",
-				DevProvider:          true,
 				Parallelism:          1,
 				ModulePath:           "", // Import to the root module
 			},


### PR DESCRIPTION
The module will needs to be initialized by `terrform init` for the `TestAppendToModule` test case, while it won't be called if `--dev-provider` is used.